### PR TITLE
Updated to Swift 3 - Xcode 8

### DIFF
--- a/Playgrounds/1a_I_See_No_Nil.playground/Sources/SupportCode.swift
+++ b/Playgrounds/1a_I_See_No_Nil.playground/Sources/SupportCode.swift
@@ -1,7 +1,7 @@
 /*
 nil/Optional is a difficult topic to cover because Xcode's display of Optional types is a big lie.
 Xcode will display Optionals as plain values if they have an associated value 
-and it will display the value as nil if the value of the Optional is .None.
+and it will display the value as nil if the value of the Optional is .none.
 
 Below is a function (optToString) that will convert Optionals to a sensible String value.
 
@@ -15,7 +15,7 @@ Therefore optToString will curiously accept non-optional values as input.
 
 import Foundation
 
-public func optToString<T>(v: T?) -> String {
+public func optToString<T>(_ v: T?) -> String {
 /*
     "\(T.self)" gets the type of the parameter as a String. Examples:
     
@@ -32,26 +32,26 @@ public func optToString<T>(v: T?) -> String {
     Optional("hi")
     Optional([1,2,3])
     
-    Need to replace 'nil' with '.None'
+    Need to replace 'nil' with '.none'
     Need to remove '(' and ')' from the String
     
     ######################################################
 
     Desired String format examples:
     
-    Optional<Int>.None
-    Optional<Array<String>>.None
-    Optional<String>.Some("hi")
-    Optional<Array<Int>>.Some([1,2,3])
+    Optional<Int>.none
+    Optional<Array<String>>.none
+    Optional<String>.some("hi")
+    Optional<Array<Int>>.some([1,2,3])
     
 */
 
-    let type = "\(T.self)".stringByReplacingOccurrencesOfString("Swift.", withString:"")
+    let type = "\(T.self)".replacingOccurrences(of: "Swift.", with:"")
     let value = "\(v.self)"
 
     if value != "nil" {
         let v = value.characters.split { $0 == "(" || $0 == ")" }.map(String.init)
-        return v.joinWithSeparator("<\(type)>.Some(") + ")"
+        return v.joined(separator: "<\(type)>.some(") + ")"
     }
-    return "Optional<\(type)>.None"
+    return "Optional<\(type)>.none"
 }

--- a/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
+++ b/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
@@ -21,8 +21,8 @@ What value can **nil** become? Well, almost certainly, it will become an **Optio
 that has two possible cases. Here it is:
 
     enum Optional<T> {
-        case None
-        case Some(T)
+        case none
+        case some(T)
     }
 
 Instead of **nil** the potential non-existence of a value will be represented by the **Optional** type.
@@ -33,7 +33,7 @@ If you miss the good old days of runtime **nil** crashes, then you can just thro
 * * *
 
 Unfortunately, Xcode is really unhelpful when displaying **Optional** values –
-*.None* is displayed as *nil* and wrapped values are displayed as plain values.
+*.none* is displayed as *nil* and wrapped values are displayed as plain values.
 The function *optToString*, used in the code below is not a Swift library function,
 it has been added to give useful **String** representations of **Optionals**.
 Take a look in the *Sources* folder if you're interested in why and how it's implemented.
@@ -76,11 +76,11 @@ Here's an example of how the **Optional** type can conform to the **NilLiteralCo
 
     enum Optional<T> : NilLiteralConvertible {
         init(nilLiteral: ()) {
-            self = None
+            self = none
         }
     }
 
-The only sensible value for the **Optional** is the **None** case.
+The only sensible value for the **Optional** is the **none** case.
 
 * * *
 
@@ -91,15 +91,15 @@ the type must conform to the **NilLiteralConvertible** protocol. Example:
 
 * * *
 
-Instead of assigning **nil** to a variable, it is perfectly valid to assign **.None**.
+Instead of assigning **nil** to a variable, it is perfectly valid to assign **.none**.
 In fact, the result is exactly the same and it is also immediately clear that an **Optional** is being assigned – 
 consequently, the expression does not need to be squeezed through the **NilLiteralConvertible** sausage machine.
 */
 
-let a1: Int? = .None
+let a1: Int? = .none
 optToString(a1)
 
-let b1: String? = .None
+let b1: String? = .none
 optToString(b)
 
 /*:
@@ -110,7 +110,7 @@ One way to query an **Optional** value to find out if it has an *associated valu
 **But, is equality really tested against *nil*? *No***, it will be transformed into a valid value with **NilLiteralConvertible**.
 
 Just as in the examples above (where **nil** is assigned to a variable), the value of the variable is never **nil**, 
-it is **Optional<T>.None** (where **T** is an actual type, such as *Int*, *String*, etc).
+it is **Optional<T>.none** (where **T** is an actual type, such as *Int*, *String*, etc).
 
 * * *
 
@@ -129,13 +129,13 @@ f != nil
 /*:
 If the types can be inferred, explicit type declarations are not required.
 The **Int()** initializer with a String argument returns an **Optional<Int>**.
-Also, just like assigning **.None** to a variable, it's perfectly valid (and arguably clearer) to test for equality with **.None**
+Also, just like assigning **.none** to a variable, it's perfectly valid (and arguably clearer) to test for equality with **.none**
 */
 let g = Int("hello")
-g != .None
+g != .none
 
 let h: Int? = Int("42")
-h != .None
+h != .none
 /*:
 When a variable is declared as an **Optional** it is possible to assign a *non-optional* value to the variable.
 The *non-optional* value will be automatically wrapped in an **Optional**.
@@ -146,7 +146,7 @@ For example the same does not apply to other ‘containers’, such as **Array**
 
 Whereas the following is acceptable:
 
-    let x:Int? = 8 // result is: Optional<Int>.Some(8)
+    let x:Int? = 8 // result is: Optional<Int>.some(8)
 
 * * *
 
@@ -162,18 +162,18 @@ nil < 0
 The first thing to recall is that **nil** isn't really **nil**, it's an **Optional**.
 What we really have is:
 
-    .None < 0
+    .none < 0
 */
-(.None) < 0
+(.none) < 0
 
 /*:
-The question is: What type of **.None** is it? It's an **Optional**, 
+The question is: What type of **.none** is it? It's an **Optional**, 
 but an **Optional** must have an associated type. In this instance
-the only sensible type is **Int**. Therefore **.None** can be expanded to:
+the only sensible type is **Int**. Therefore **.none** can be expanded to:
 
-    Optional<Int>.None < 0
+    Optional<Int>.none < 0
 */
-Optional<Int>.None < 0
+Optional<Int>.none < 0
 
 /*:
 We've fully expanded the type of **nil**, but there's another problem to address.
@@ -192,7 +192,7 @@ There isn't another overload of the **<** operator that accepts **Optionals** an
 As previously mentioned, it's possible (and normal practice) to declare an **Optional** type then assign
 a normal value to it:
 
-    let x:Int? = 8 // result is: Optional<Int>.Some(8)
+    let x:Int? = 8 // result is: Optional<Int>.some(8)
 
 The same thing occurs when a parameter to a function is an **Optional** value -
 a non-optional can be passed to the function and it will automatically become an **Optional** within the context of the function.
@@ -201,17 +201,17 @@ This implicit behaviour doesn't have an official name, but **automatic Optional 
 
 Therefore in the expression:
 
-    Optional<Int>.None < 0
+    Optional<Int>.none < 0
 
 The right hand side is automatically lifted into an **Optional**:
 
-    Optional<Int>.None < .Some(0)
+    Optional<Int>.none < .some(0)
 
 To give the most explicit and verbose form:
 
-    Optional<Int>.None < Optional<Int>.Some(0)
+    Optional<Int>.none < Optional<Int>.some(0)
 */
-Optional<Int>.None < Optional<Int>.Some(0)
+Optional<Int>.none < Optional<Int>.some(0)
 
 /*:
 The seemingly simple expression:
@@ -220,16 +220,16 @@ The seemingly simple expression:
 
 Will, after compilation, become:
 
-    Optional<Int>.None < Optional<Int>.Some(0)
+    Optional<Int>.none < Optional<Int>.some(0)
 
 Here is an implementation of **<** for **Optional** types - 
-**.None** is by default always less than **.Some**. When both values are **.Some**, 
+**.none** is by default always less than **.some**. When both values are **.some**, 
 their wrapped values are compared to give a result.
 
     func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         switch (lhs, rhs) {
-        case (.None, .Some) : return true
-        case let (.Some(x), .Some(y)) : return x < y
+        case (.none, .some) : return true
+        case let (.some(x), .some(y)) : return x < y
         default : return false
         }
     }
@@ -242,9 +242,9 @@ The same logic applies to all **Comparable** types. Here's an example with **Str
 */
 "a" > nil
 
-"a" > .None
+"a" > .none
 
-Optional<String>.Some("a") > Optional<String>.None
+Optional<String>.some("a") > Optional<String>.none
 
 /*:
 * * *

--- a/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
+++ b/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
@@ -152,10 +152,29 @@ Whereas the following is acceptable:
 
 ## Is *nil* less than zero?
 
+Update for Swift 3: this section is no longer relevant in Swift 3 due to [SE-0121 "Remove Optional Comparison Operators"](https://github.com/apple/swift-evolution/blob/master/proposals/0121-remove-optional-comparison-operators.md).
+
+For educational purposes, we assume that there are still implementations of Optional Comparison Operators.
+*/
+func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+	switch (lhs, rhs) {
+	case (.none, .some) : return true
+	case let (.some(x), .some(y)) : return x < y
+	default : return false
+	}
+}
+
+func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+	switch (lhs, rhs) {
+	case (.some, .none) : return true
+	case let (.some(x), .some(y)) : return x > y
+	default : return false
+	}
+}
+/*:
 You might expect **nil** to be equal to zero. Well is it?
 */
 nil < 0
-
 /*:
 **It turns out that *nil* is less than zero. How can this be?**
 

--- a/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
+++ b/Playgrounds/1a_I_See_No_Nil.playground/contents.swift
@@ -62,19 +62,19 @@ optToString(c)
 The examples above show an assigment of **nil**, yet the value of the variable is not **nil**, it's an **Optional**.
 Is there some secret compiler shenanigans ocurring which is responsible for figuring out how to transform **nil**
 into a normal, useable value? Well, not really. The mechanism responsible for transforming **nil** into something useful
-is the protocol, **NilLiteralConvertible**. Here it is:
+is the protocol, **ExpressibleByNilLiteral**. Here it is:
 
-    protocol NilLiteralConvertible {
+    protocol ExpressibleByNilLiteral {
         init(nilLiteral: ())
     }
 
-Nothing magical there. If a type conforms to the **NilLiteralConvertible** protocol, it must implement an *init* method
+Nothing magical there. If a type conforms to the **ExpressibleByNilLiteral** protocol, it must implement an *init* method
 which can produce a default value of the type. The *init* method receives one argument containing no useful information 
 (it is merely the *empty tuple*). It is therefore impossible to derive any information from the
 argument (it's simply a stand-in for *nil*) and a *default* value must be returned from the method. 
-Here's an example of how the **Optional** type can conform to the **NilLiteralConvertible** protocol:
+Here's an example of how the **Optional** type can conform to the **ExpressibleByNilLiteral** protocol:
 
-    enum Optional<T> : NilLiteralConvertible {
+    enum Optional<T> : ExpressibleByNilLiteral {
         init(nilLiteral: ()) {
             self = none
         }
@@ -85,15 +85,15 @@ The only sensible value for the **Optional** is the **none** case.
 * * *
 
 It's not possible to assign **nil** to any type of value,
-the type must conform to the **NilLiteralConvertible** protocol. Example:
+the type must conform to the **ExpressibleByNilLiteral** protocol. Example:
 
-    let v:Int = nil // *Error* Type 'Int' does not conform to protocol 'NilLiteralConvertible'
+    let v:Int = nil // *Error* Type 'Int' does not conform to protocol 'ExpressibleByNilLiteral'
 
 * * *
 
 Instead of assigning **nil** to a variable, it is perfectly valid to assign **.none**.
 In fact, the result is exactly the same and it is also immediately clear that an **Optional** is being assigned – 
-consequently, the expression does not need to be squeezed through the **NilLiteralConvertible** sausage machine.
+consequently, the expression does not need to be squeezed through the **ExpressibleByNilLiteral** sausage machine.
 */
 
 let a1: Int? = .none
@@ -107,7 +107,7 @@ optToString(b)
 
 One way to query an **Optional** value to find out if it has an *associated value* is to test for equality with **‘nil’**.
 
-**But, is equality really tested against *nil*? *No***, it will be transformed into a valid value with **NilLiteralConvertible**.
+**But, is equality really tested against *nil*? *No***, it will be transformed into a valid value with **ExpressibleByNilLiteral**.
 
 Just as in the examples above (where **nil** is assigned to a variable), the value of the variable is never **nil**, 
 it is **Optional<T>.none** (where **T** is an actual type, such as *Int*, *String*, etc).
@@ -249,5 +249,5 @@ Optional<String>.some("a") > Optional<String>.none
 /*:
 * * *
 
-That's the end of this expedition into the heart of darkness of **nil**, **NilLiteralConvertible** and **Optional** values.
+That's the end of this expedition into the heart of darkness of **nil**, **ExpressibleByNilLiteral** and **Optional** values.
 */

--- a/Playgrounds/1a_I_See_No_Nil.playground/contents.xcplayground
+++ b/Playgrounds/1a_I_See_No_Nil.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='rendered'>
+<playground version='5.0' target-platform='ios' display-mode='rendered' last-migration='0800'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Playgrounds/1a_I_See_No_Nil.playground/timeline.xctimeline
+++ b/Playgrounds/1a_I_See_No_Nil.playground/timeline.xctimeline
@@ -23,7 +23,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=6&amp;CharacterRangeLoc=5392&amp;EndingColumnNumber=9&amp;EndingLineNumber=135&amp;StartingColumnNumber=1&amp;StartingLineNumber=135&amp;Timestamp=472921482.915773"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5392&amp;EndingColumnNumber=6&amp;EndingLineNumber=136&amp;StartingColumnNumber=5&amp;StartingLineNumber=136&amp;Timestamp=493194085.270336"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/1b_Going_Bananas.playground/contents.swift
+++ b/Playgrounds/1b_Going_Bananas.playground/contents.swift
@@ -1,7 +1,7 @@
 /*:
 ## Let's go bananas
 
-*NilLiteralConvertible* is not just for **Optionals**.
+*ExpressibleByNilLiteral* is not just for **Optionals**.
 However, having said that, you need a very good reason to adopt the protocol.
 A fruity cautionary tale is presented below.
 
@@ -18,12 +18,12 @@ extension 🍌 : CustomStringConvertible {
     var description: String { return "🍌" } // these bananas are all identical
 }
 /*:
-With a little help from *NilLiteralConvertible*, we can introduce some danger.
+With a little help from *ExpressibleByNilLiteral*, we can introduce some danger.
 For convenience a plain *init()* method will also be added, enabling a **Banana** to be created with 🍌()
 */
-extension 🍌 : NilLiteralConvertible {
-    init() { self = 🍌 }
-    init(nilLiteral: ()) { self = 🍌 }
+extension 🍌 : ExpressibleByNilLiteral {
+    init() { self = .🍌 }
+    init(nilLiteral: ()) { self = .🍌 }
 }
 //: Let's create a **Banana** – nothing too interesting yet
 let b = 🍌()
@@ -70,7 +70,7 @@ print(bananaBox)
 ## **Now that's magic!**
 
 Well, it isn't actually. It's quite obvious when you think about it.
-**Banana** is *NilLiteralConvertible*, therefore, Swift will happily replace all instances of **nil**
+**Banana** is *ExpressibleByNilLiteral*, therefore, Swift will happily replace all instances of **nil**
 with a **Banana**, as long as the type checker is satisfied. You can't, for example, assign **nil**
 to a variable without type annotations and expect it to become a **Banana**:
 

--- a/Playgrounds/1b_Going_Bananas.playground/timeline.xctimeline
+++ b/Playgrounds/1b_Going_Bananas.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1353&amp;EndingColumnNumber=12&amp;EndingLineNumber=45&amp;StartingColumnNumber=2&amp;StartingLineNumber=45&amp;Timestamp=472922156.631434"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1357&amp;EndingColumnNumber=12&amp;EndingLineNumber=45&amp;StartingColumnNumber=2&amp;StartingLineNumber=45&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -23,43 +23,43 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=84&amp;CharacterRangeLoc=1508&amp;EndingColumnNumber=17&amp;EndingLineNumber=55&amp;StartingColumnNumber=1&amp;StartingLineNumber=55&amp;Timestamp=472922156.632867"
+         documentLocation = "#CharacterRangeLen=84&amp;CharacterRangeLoc=1512&amp;EndingColumnNumber=17&amp;EndingLineNumber=55&amp;StartingColumnNumber=1&amp;StartingLineNumber=55&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1652&amp;EndingColumnNumber=14&amp;EndingLineNumber=61&amp;StartingColumnNumber=5&amp;StartingLineNumber=61&amp;Timestamp=472922156.63327"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1656&amp;EndingColumnNumber=14&amp;EndingLineNumber=61&amp;StartingColumnNumber=5&amp;StartingLineNumber=61&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1774&amp;EndingColumnNumber=10&amp;EndingLineNumber=66&amp;StartingColumnNumber=1&amp;StartingLineNumber=66&amp;Timestamp=472922156.633583"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1778&amp;EndingColumnNumber=10&amp;EndingLineNumber=66&amp;StartingColumnNumber=1&amp;StartingLineNumber=66&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1766&amp;EndingColumnNumber=19&amp;EndingLineNumber=66&amp;StartingColumnNumber=1&amp;StartingLineNumber=66&amp;Timestamp=472922156.633886"
+         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1770&amp;EndingColumnNumber=19&amp;EndingLineNumber=66&amp;StartingColumnNumber=1&amp;StartingLineNumber=66&amp;Timestamp=491817222.401419"
          lockedSize = "{452, 106}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=509&amp;EndingColumnNumber=1&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=29&amp;Timestamp=472922156.634202"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=509&amp;EndingColumnNumber=1&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=29&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=577&amp;EndingColumnNumber=19&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=28&amp;Timestamp=472922156.634506"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=577&amp;EndingColumnNumber=19&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=28&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=421&amp;EndingColumnNumber=16&amp;EndingLineNumber=17&amp;StartingColumnNumber=1&amp;StartingLineNumber=17&amp;Timestamp=472922156.634806"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=421&amp;EndingColumnNumber=16&amp;EndingLineNumber=17&amp;StartingColumnNumber=1&amp;StartingLineNumber=17&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=510&amp;EndingColumnNumber=1&amp;EndingLineNumber=30&amp;StartingColumnNumber=1&amp;StartingLineNumber=30&amp;Timestamp=472922156.635112"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=510&amp;EndingColumnNumber=1&amp;EndingLineNumber=30&amp;StartingColumnNumber=1&amp;StartingLineNumber=30&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -74,7 +74,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=417&amp;EndingColumnNumber=19&amp;EndingLineNumber=21&amp;StartingColumnNumber=1&amp;StartingLineNumber=21&amp;Timestamp=472922156.63591"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=417&amp;EndingColumnNumber=19&amp;EndingLineNumber=21&amp;StartingColumnNumber=1&amp;StartingLineNumber=21&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -89,17 +89,17 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=416&amp;EndingColumnNumber=19&amp;EndingLineNumber=20&amp;StartingColumnNumber=1&amp;StartingLineNumber=20&amp;Timestamp=472922156.636803"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=416&amp;EndingColumnNumber=19&amp;EndingLineNumber=20&amp;StartingColumnNumber=1&amp;StartingLineNumber=20&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=434&amp;EndingColumnNumber=11&amp;EndingLineNumber=21&amp;StartingColumnNumber=1&amp;StartingLineNumber=21&amp;Timestamp=472922156.637105"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=434&amp;EndingColumnNumber=11&amp;EndingLineNumber=21&amp;StartingColumnNumber=1&amp;StartingLineNumber=21&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=426&amp;EndingColumnNumber=17&amp;EndingLineNumber=20&amp;StartingColumnNumber=1&amp;StartingLineNumber=20&amp;Timestamp=472922156.654679"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=426&amp;EndingColumnNumber=17&amp;EndingLineNumber=20&amp;StartingColumnNumber=1&amp;StartingLineNumber=20&amp;Timestamp=491817222.401419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/2a_Maybe_Type.playground/Sources/SupportCode.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/Sources/SupportCode.swift
@@ -1,11 +1,11 @@
 
 // Declare The Maybe type to use with MaybeDictionary
 public enum Maybe<T> : NilLiteralConvertible {
-    case None, Some(T)
+    case none, some(T)
     
-    public init() { self = None }
-    public init(_ some: T) { self = Some(some) }
-    public init(nilLiteral: ()) { self = None }
+    public init() { self = none }
+    public init(_ s: T) { self = some(s) }
+    public init(nilLiteral: ()) { self = none }
 }
 
 
@@ -18,7 +18,7 @@ public struct MaybeDictionary<Key: Hashable, Value>: DictionaryLiteralConvertibl
     private typealias Storage = [Element]
     private var _store: Storage = []
     
-    private func _indexForKey(key: Key) -> Storage.Index? {
+    private func _indexForKey(_ key: Key) -> Storage.Index? {
         for (idx, (k, _)) in zip(_store.indices, _store) {
             if key == k { return idx }
         }
@@ -30,22 +30,22 @@ public struct MaybeDictionary<Key: Hashable, Value>: DictionaryLiteralConvertibl
             if let idx = _indexForKey(key) {
                 return Maybe(_store[idx].1)
             }
-            return .None
+            return .none
         }
         
         set(newValue) {
             switch (_indexForKey(key), newValue) {
                 
-            case let (.Some(idx), .Some(value)):
+            case let (.some(idx), .some(value)):
                 _store[idx].1 = value
                 
-            case let (.Some(idx), .None):
-                _store.removeAtIndex(idx)
+            case let (.some(idx), .none):
+                _store.remove(at: idx)
                 
-            case let (.None, .Some(value)):
+            case let (.none, .some(value)):
                 _store.append((key, value))
                 
-            case (.None,.None): break
+            case (.none,.none): break
             }
         }
     }

--- a/Playgrounds/2a_Maybe_Type.playground/Sources/SupportCode.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/Sources/SupportCode.swift
@@ -1,11 +1,11 @@
 
 // Declare The Maybe type to use with MaybeDictionary
-public enum Maybe<T> : NilLiteralConvertible {
+public enum Maybe<T> : ExpressibleByNilLiteral {
     case none, some(T)
     
-    public init() { self = none }
-    public init(_ s: T) { self = some(s) }
-    public init(nilLiteral: ()) { self = none }
+    public init() { self = .none }
+    public init(_ s: T) { self = .some(s) }
+    public init(nilLiteral: ()) { self = .none }
 }
 
 
@@ -13,7 +13,7 @@ public enum Maybe<T> : NilLiteralConvertible {
 The implementation of MaybeDictionary is adapted from http://airspeedvelocity.net
 */
 
-public struct MaybeDictionary<Key: Hashable, Value>: DictionaryLiteralConvertible {
+public struct MaybeDictionary<Key: Hashable, Value>: ExpressibleByDictionaryLiteral {
     public typealias Element = (Key, Value)
     private typealias Storage = [Element]
     private var _store: Storage = []

--- a/Playgrounds/2a_Maybe_Type.playground/contents.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/contents.swift
@@ -4,7 +4,7 @@
 The purpose of implementing our own **Optional** type is to demonstrate that **Optionals** are simple **enum values**.
 
 As the **Optional** type already exists, we'll need a new name.
-The name **Maybe** is taken from Haskell, but the two cases *None* & *Some*
+The name **Maybe** is taken from Haskell, but the two cases *none* & *some*
 are the same as Swift's **Optional** type (Haskell uses *Nothing* & *Just*).
 The **Maybe** type conforms to *NilLiteralConvertible*, as does Swift's **Optional** type.
 This allows a **Maybe** value to be constructed from *nil*.
@@ -13,36 +13,36 @@ This allows a **Maybe** value to be constructed from *nil*.
 One aspect of Swift's **Optional** type which can't be reproduced is
 *implicit Optional wrapping*. Here's an example:
 
-    .None < 0
+    .none < 0
 
 Such a comparison should not be possible as the types don't match.
 However, Swift will automatically convert the expression to:
 
-    .None < .Some(0)
+    .none < .some(0)
 
 It's impossible to reproduce the recipe for this secret sauce – it's an
 **Optional** only capability which is often convenient, sometimes bizarre.
 *Implicit Optional wrapping* also comes into play when returning **Optional**
 values from functions. When reimplementing **Optionals**, values must always
-be explicity wrapped using *Maybe(x)*, or by using the *.Some(x)* constructor.
+be explicity wrapped using *Maybe(x)*, or by using the *.some(x)* constructor.
 */
 
 enum Maybe<T> : NilLiteralConvertible {
-    case None
-    case Some(T)
+    case none
+    case some(T)
     
-    init() { self = None } // init with no args defaults to 'None'
-    init(_ some: T) { self = Some(some) }
-    init(nilLiteral: ()) { self = None } // init with 'nil' defaults to 'None'
+    init() { self = none } // init with no args defaults to 'none'
+    init(_ s: T) { self = some(s) }
+    init(nilLiteral: ()) { self = none } // init with 'nil' defaults to 'none'
 /*:
 *map* takes a normal function from *T -> U* and runs it inside the **Maybe**.
-* If the value of **self** is *.None* the function is not applied and *.None* is returned.
-* If *self* matches the *.Some* case, then the function is applied to the *Associated Value* and wrapped in a **Maybe**
+* If the value of **self** is *.none* the function is not applied and *.none* is returned.
+* If *self* matches the *.some* case, then the function is applied to the *Associated Value* and wrapped in a **Maybe**
 */
-    func map<U>(f: T -> U) -> Maybe<U> {
+    func map<U>(_ f: (T) -> U) -> Maybe<U> {
         switch self {
-        case .None : return .None
-        case .Some(let x) : return .Some(f(x))
+        case .none : return .none
+        case .some(let x) : return .some(f(x))
         }
     }
 }
@@ -50,8 +50,8 @@ enum Maybe<T> : NilLiteralConvertible {
 extension Maybe : CustomStringConvertible {
     var description: String {
         switch self {
-        case .None : return "{None}"
-        case .Some(let x) : return "{Some \(x)}"
+        case .none : return "{none}"
+        case .some(let x) : return "{some \(x)}"
         }
     }
 }
@@ -71,16 +71,16 @@ we don't get any operators for free :(
 
 func == <T: Equatable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .None) : return true
-    case let (.Some(x), .Some(y)) : return x == y
+    case (.none, .none) : return true
+    case let (.some(x), .some(y)) : return x == y
     default : return false
     }
 }
 
 func < <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .Some) : return true
-    case let (.Some(x), .Some(y)) : return x < y
+    case (.none, .some) : return true
+    case let (.some(x), .some(y)) : return x < y
     default : return false
     }
 }
@@ -144,7 +144,7 @@ let dict = [1:[2:[3:"Hello!"]]]
 let val = dict[1]?[2]?[3]
 
 /*:
-The type of *val* is not a plain **String**, it is an **Optional** (*.Some("Hello!")*) - Xcode lies a little!
+The type of *val* is not a plain **String**, it is an **Optional** (*.some("Hello!")*) - Xcode lies a little!
 
 * * *
 
@@ -165,14 +165,14 @@ Now the difficulty arises: how do we subscript into the nested *Dictionary* to r
 let v: Maybe<String>
 
 switch mDict[1] {
-case .None : v = .None
-case .Some(let d) :
+case .none : v = .none
+case .some(let d) :
     switch d[2] {
-    case .None : v = .None
-    case .Some(let d) :
+    case .none : v = .none
+    case .some(let d) :
         switch d[3] {
-        case .None : v = .None
-        case .Some(let x) : v = .Some(x)
+        case .none : v = .none
+        case .some(let x) : v = .some(x)
         }
     }
 }

--- a/Playgrounds/2a_Maybe_Type.playground/contents.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/contents.swift
@@ -13,12 +13,12 @@ This allows a **Maybe** value to be constructed from *nil*.
 One aspect of Swift's **Optional** type which can't be reproduced is
 *implicit Optional wrapping*. Here's an example:
 
-    .none < 0
+    .some(0) == 0
 
 Such a comparison should not be possible as the types don't match.
 However, Swift will automatically convert the expression to:
 
-    .none < .some(0)
+    .some(0) == .some(0)
 
 It's impossible to reproduce the recipe for this secret sauce – it's an
 **Optional** only capability which is often convenient, sometimes bizarre.
@@ -56,37 +56,24 @@ extension Maybe : CustomStringConvertible {
     }
 }
 /*:
-### *Equatable* & *Comparable* protocols
+### *Equatable* protocol
 
-The built in **Optional** type does not conform to the *Equatable* or *Comparable* protocols.
-Conforming to these protocols would prevent non-comparable values from being declared **Optional**.
+The built in **Optional** type does not conform to the *Equatable* protocol.
+Conforming to this protocol would prevent non-equatable values from being declared **Optional**.
 This is what the type restriction would look like:
 
-    enum Optional<T:Comparable> {}
+    enum Optional<T:Equatable> {}
 
-There are however overloaded operators for equality and comparison that accept **Optionals**.
-Below are a few overloaded operators for the **Maybe** type. As we can't conform to *Comparable*
+There is however an overloaded operator for equality that accepts **Optionals**.
+Below is an overloaded equality operator for the **Maybe** type. As we can't conform to *Equatable*
 we don't get any operators for free :(
 */
-
 func == <T: Equatable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
     case (.none, .none) : return true
     case let (.some(x), .some(y)) : return x == y
     default : return false
     }
-}
-
-func < <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
-    switch (lhs, rhs) {
-    case (.none, .some) : return true
-    case let (.some(x), .some(y)) : return x < y
-    default : return false
-    }
-}
-
-func > <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
-    return rhs < lhs
 }
 /*:
 ### Usage of Custom *Maybe* Type
@@ -103,12 +90,10 @@ let m2 = m1.map { $0 + 1 }
 print(m2)
 //: Comparing **Maybe** types
 m1 == m2 // Maybe(1) == Maybe(2)
-m1 < m2 // Maybe(1) < Maybe(2)
-m1 > m2 // Maybe(1) > Maybe(2)
 //: *ExpressibleByNilLiteral* in action on custom **Maybe** type
-nil < m1 // ExpressibleByNilLiteral is invoked to contruct a Maybe value from 'nil'
+nil == m1 // ExpressibleByNilLiteral is invoked to contruct a Maybe value from 'nil'
 //: Example of, *implicit Optional wrapping* with **Optionals**
-Optional(1) < 2
+Optional(1) == 1
 /*:
 the equivalent code using **Maybe** will not compile
 

--- a/Playgrounds/2a_Maybe_Type.playground/contents.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/contents.swift
@@ -6,7 +6,7 @@ The purpose of implementing our own **Optional** type is to demonstrate that **O
 As the **Optional** type already exists, we'll need a new name.
 The name **Maybe** is taken from Haskell, but the two cases *none* & *some*
 are the same as Swift's **Optional** type (Haskell uses *Nothing* & *Just*).
-The **Maybe** type conforms to *NilLiteralConvertible*, as does Swift's **Optional** type.
+The **Maybe** type conforms to *ExpressibleByNilLiteral*, as does Swift's **Optional** type.
 This allows a **Maybe** value to be constructed from *nil*.
 
 ### What can't be implemented?
@@ -27,7 +27,7 @@ values from functions. When reimplementing **Optionals**, values must always
 be explicity wrapped using *Maybe(x)*, or by using the *.some(x)* constructor.
 */
 
-enum Maybe<T> : NilLiteralConvertible {
+enum Maybe<T> : ExpressibleByNilLiteral {
     case none
     case some(T)
     
@@ -105,8 +105,8 @@ print(m2)
 m1 == m2 // Maybe(1) == Maybe(2)
 m1 < m2 // Maybe(1) < Maybe(2)
 m1 > m2 // Maybe(1) > Maybe(2)
-//: *NilLiteralConvertible* in action on custom **Maybe** type
-nil < m1 // NilLiteralConvertible is invoked to contruct a Maybe value from 'nil'
+//: *ExpressibleByNilLiteral* in action on custom **Maybe** type
+nil < m1 // ExpressibleByNilLiteral is invoked to contruct a Maybe value from 'nil'
 //: Example of, *implicit Optional wrapping* with **Optionals**
 Optional(1) < 2
 /*:

--- a/Playgrounds/2a_Maybe_Type.playground/contents.swift
+++ b/Playgrounds/2a_Maybe_Type.playground/contents.swift
@@ -31,9 +31,9 @@ enum Maybe<T> : ExpressibleByNilLiteral {
     case none
     case some(T)
     
-    init() { self = none } // init with no args defaults to 'none'
-    init(_ s: T) { self = some(s) }
-    init(nilLiteral: ()) { self = none } // init with 'nil' defaults to 'none'
+    init() { self = .none } // init with no args defaults to 'none'
+    init(_ s: T) { self = .some(s) }
+    init(nilLiteral: ()) { self = .none } // init with 'nil' defaults to 'none'
 /*:
 *map* takes a normal function from *T -> U* and runs it inside the **Maybe**.
 * If the value of **self** is *.none* the function is not applied and *.none* is returned.

--- a/Playgrounds/2a_Maybe_Type.playground/contents.xcplayground
+++ b/Playgrounds/2a_Maybe_Type.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='rendered'>
+<playground version='5.0' target-platform='ios' display-mode='rendered' last-migration='0800'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
+++ b/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
@@ -18,12 +18,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1361&amp;EndingColumnNumber=9&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.896469"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1362&amp;EndingColumnNumber=9&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.845468"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.264489"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.845578"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -48,27 +48,27 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1396&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265106"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1397&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.846092"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=1&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265231"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=1&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.846197"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=18&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265362"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=18&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.846301"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=14&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=491663898.265491"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=14&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=492587544.846404"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=13&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=491663898.26562"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=13&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=492587544.846504"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -93,7 +93,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1399&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=491663898.266227"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1400&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=492587544.847006"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -113,47 +113,47 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=37&amp;EndingLineNumber=54&amp;StartingColumnNumber=23&amp;StartingLineNumber=54&amp;Timestamp=491663898.266701"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=37&amp;EndingLineNumber=54&amp;StartingColumnNumber=23&amp;StartingLineNumber=54&amp;Timestamp=492587544.847399"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.266825"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.847501"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.266963"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=492587544.847602"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1441&amp;EndingColumnNumber=8&amp;EndingLineNumber=56&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=491663904.730431"
+         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1443&amp;EndingColumnNumber=8&amp;EndingLineNumber=56&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=492587548.527824"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1776&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730588"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1779&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048529"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1780&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730724"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1783&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048713"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1788&amp;EndingColumnNumber=9&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730854"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1791&amp;EndingColumnNumber=9&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048891"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1449&amp;EndingColumnNumber=8&amp;EndingLineNumber=55&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=491663904.73098"
+         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1451&amp;EndingColumnNumber=8&amp;EndingLineNumber=55&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=492587548.528295"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1405&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=491663902.97359"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1406&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=492587544.848306"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
+++ b/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
@@ -23,7 +23,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.896767"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.264489"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -48,27 +48,27 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1396&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.898249"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1396&amp;EndingColumnNumber=16&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265106"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=1&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.898544"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=1&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265231"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=18&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.898836"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=18&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.265362"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=14&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=472929381.899172"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=14&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=491663898.265491"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=13&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=472929381.899468"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=13&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=491663898.26562"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -93,7 +93,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1400&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=472929381.900946"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1399&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=491663898.266227"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -113,47 +113,47 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=37&amp;EndingLineNumber=54&amp;StartingColumnNumber=23&amp;StartingLineNumber=54&amp;Timestamp=472929381.902186"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=37&amp;EndingLineNumber=54&amp;StartingColumnNumber=23&amp;StartingLineNumber=54&amp;Timestamp=491663898.266701"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.902496"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.266825"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1415&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=472929381.9028"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=11&amp;EndingLineNumber=54&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=491663898.266963"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1452&amp;EndingColumnNumber=8&amp;EndingLineNumber=56&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=472929381.903109"
+         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1441&amp;EndingColumnNumber=8&amp;EndingLineNumber=56&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=491663904.730431"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1787&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=472929875.277351"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1776&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730588"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1791&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=472929875.277646"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1780&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730724"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1799&amp;EndingColumnNumber=9&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=472929875.27794"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1788&amp;EndingColumnNumber=9&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491663904.730854"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1460&amp;EndingColumnNumber=8&amp;EndingLineNumber=55&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=472929381.90425"
+         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1449&amp;EndingColumnNumber=8&amp;EndingLineNumber=55&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=491663904.73098"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1408&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=472929381.937024"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1405&amp;EndingColumnNumber=16&amp;EndingLineNumber=53&amp;StartingColumnNumber=1&amp;StartingLineNumber=53&amp;Timestamp=491663902.97359"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
+++ b/Playgrounds/2a_Maybe_Type.playground/timeline.xctimeline
@@ -133,17 +133,17 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1779&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048529"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1779&amp;EndingColumnNumber=11&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=493195023.250297"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1783&amp;EndingColumnNumber=11&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048713"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1783&amp;EndingColumnNumber=11&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=493195023.250416"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1791&amp;EndingColumnNumber=9&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=492587550.048891"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1791&amp;EndingColumnNumber=9&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=493195023.25053"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/Sources/SupportCode.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/Sources/SupportCode.swift
@@ -1,14 +1,14 @@
 public enum Maybe<T> : NilLiteralConvertible {
-    case None, Some(T)
+    case none, some(T)
     
-    public init() { self = None }
-    public init(_ some: T) { self = Some(some) }
-    public init(nilLiteral: ()) { self = None }
+    public init() { self = none }
+    public init(_ s: T) { self = some(s) }
+    public init(nilLiteral: ()) { self = none }
     
-    func map<U>(f: T -> U) -> Maybe<U> {
+    func map<U>(_ f: (T) -> U) -> Maybe<U> {
         switch self {
-        case .None : return .None
-        case .Some(let x) : return .Some(f(x))
+        case .none : return .none
+        case .some(let x) : return .some(f(x))
         }
     }
 }
@@ -16,24 +16,24 @@ public enum Maybe<T> : NilLiteralConvertible {
 extension Maybe : CustomStringConvertible {
     public var description: String {
         switch self {
-        case .None : return "{None}"
-        case .Some(let x) : return "{Some \(x)}"
+        case .none : return "{none}"
+        case .some(let x) : return "{some \(x)}"
         }
     }
 }
 
 public func == <T: Equatable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .None) : return true
-    case let (.Some(x), .Some(y)) : return x == y
+    case (.none, .none) : return true
+    case let (.some(x), .some(y)) : return x == y
     default : return false
     }
 }
 
 public func < <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .Some) : return true
-    case let (.Some(x), .Some(y)) : return x < y
+    case (.none, .some) : return true
+    case let (.some(x), .some(y)) : return x < y
     default : return false
     }
 }

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/Sources/SupportCode.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/Sources/SupportCode.swift
@@ -1,9 +1,9 @@
-public enum Maybe<T> : NilLiteralConvertible {
+public enum Maybe<T> : ExpressibleByNilLiteral {
     case none, some(T)
     
-    public init() { self = none }
-    public init(_ s: T) { self = some(s) }
-    public init(nilLiteral: ()) { self = none }
+    public init() { self = .none }
+    public init(_ s: T) { self = .some(s) }
+    public init(nilLiteral: ()) { self = .none }
     
     func map<U>(_ f: (T) -> U) -> Maybe<U> {
         switch self {

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
@@ -110,7 +110,7 @@ Notice that the *pure* function is used to lift the return value into the **Mayb
 */
 func livingSpace(_ person: Maybe<Person>) -> Maybe<Int> {
     return person >>= { $0.residence }
-                  >>= { pure($0.rooms.map { $0.length * $0.width }.reduce(0, combine: +)) }
+                  >>= { pure($0.rooms.map { $0.length * $0.width }.reduce(0, +)) }
 }
 //: Call *livingSpace* function with a *Maybe<Person>*
 let bob_space = livingSpace(Maybe(bob))

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
@@ -42,7 +42,11 @@ The return value for *map* needs to be explicitly wrapped in a **Maybe** as the 
 
 Compare the implementation of **map** (above) to **>>=** to see how similar they are.
 */
-infix operator >>= { associativity left }
+precedencegroup BindPrecedence {
+	associativity: left
+	higherThan: AssignmentPrecedence
+}
+infix operator >>= : BindPrecedence
 func >>= <A,B> (m: Maybe<A>, f: (A) -> Maybe<B>) -> Maybe<B> {
     switch m {
     case .none : return .none

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
@@ -15,17 +15,17 @@ The *map* method uses *self* as an implicit first parameter, whereas the functio
 Other than that, the functionality is identical. The reason for declaring *map* as a function is to show how
 similar it is to *monadic bind* – declared below
 */
-func map<A,B>(m: Maybe<A>, _ f: A -> B) -> Maybe<B> {
+func map<A,B>(_ m: Maybe<A>, _ f: (A) -> B) -> Maybe<B> {
     switch m {
-    case .None : return .None
-    case .Some(let x) : return .Some(f(x))
+    case .none : return .none
+    case .some(let x) : return .some(f(x))
     }
 }
 //: An example of using *map* with a *Maybe<Array>* and passing a closure using the *sort* function as second parameter
-let n = map(Maybe([3,2,5,1,4])) { $0.sort() }
+let n = map(Maybe([3,2,5,1,4])) { $0.sorted() }
 print(n)
 //: *Lift* plain values into the **Maybe** type. It's the explicit equivalent of *implicit Optional wrapping*.
-func pure<A>(x: A) -> Maybe<A> {
+func pure<A>(_ x: A) -> Maybe<A> {
     return Maybe(x)
 }
 /*:
@@ -37,16 +37,16 @@ The **>>=** (bind) operator is very similar to the *map* function, declared abov
     func >>= <A,B> (m: Maybe<A>, f: A -> Maybe<B>) -> Maybe<B>
 
 The only difference between *map* and *monadic bind* is that the second parameter returns a *Maybe* for the *bind operator*.
-This means that in the *.Some* case the function **f** will return the **Maybe** that is required.
+This means that in the *.some* case the function **f** will return the **Maybe** that is required.
 The return value for *map* needs to be explicitly wrapped in a **Maybe** as the function **f** has the type *A -> B*.
 
 Compare the implementation of **map** (above) to **>>=** to see how similar they are.
 */
 infix operator >>= { associativity left }
-func >>= <A,B> (m: Maybe<A>, f: A -> Maybe<B>) -> Maybe<B> {
+func >>= <A,B> (m: Maybe<A>, f: (A) -> Maybe<B>) -> Maybe<B> {
     switch m {
-    case .None : return .None
-    case .Some(let m) : return f(m)
+    case .none : return .none
+    case .some(let m) : return f(m)
     }
 }
 /*:
@@ -93,9 +93,9 @@ struct Room { let length: Int, width: Int }
 struct Residence { let rooms: [Room] }
 struct Person { let name: String, residence: Maybe<Residence> }
 //:Create two people: one without a residence and one with a residence
-let bob = Person(name: "Bob", residence: .None)
+let bob = Person(name: "Bob", residence: .none)
 let jo = Person(name: "Jo",
-    residence: .Some(
+    residence: .some(
         Residence(rooms: [Room(length: 4, width: 3), Room(length: 2, width: 2)])
     )
 )
@@ -108,13 +108,13 @@ The use of *switch statements* would add verbosity and remove clarity.
 
 Notice that the *pure* function is used to lift the return value into the **Maybe** type.
 */
-func livingSpace(person: Maybe<Person>) -> Maybe<Int> {
+func livingSpace(_ person: Maybe<Person>) -> Maybe<Int> {
     return person >>= { $0.residence }
                   >>= { pure($0.rooms.map { $0.length * $0.width }.reduce(0, combine: +)) }
 }
 //: Call *livingSpace* function with a *Maybe<Person>*
 let bob_space = livingSpace(Maybe(bob))
-print(bob_space) // Bob has no residence, therefore the return value will be .None
+print(bob_space) // Bob has no residence, therefore the return value will be .none
 //: Call *livingSpace* function with a *Maybe<Person>*
 let jo_space = livingSpace(Maybe(jo))
 print(jo_space)
@@ -131,7 +131,7 @@ they're still happening, but concealed beneath the syntax sugar of Optional chai
 
 struct Person2 { let name: String, residence: Residence?}
 
-let jed = Person2(name: "Jed", residence: .None)
+let jed = Person2(name: "Jed", residence: .none)
 let fi = Person2(name: "Fi", residence: Residence(rooms: [Room(length: 4, width: 3), Room(length: 2, width: 2)]))
 /*:
 A function that takes a *Optional<Person>* and returns their 'livingspace' as an *Optional<Int>*
@@ -139,11 +139,11 @@ A function that takes a *Optional<Person>* and returns their 'livingspace' as an
 Values passed to the function will be automatically *lifted* into the *Optional* type.
 This differs from our custom *Maybe* type, where auto-lifting does not occur.
 */
-func livingSpace(person: Person2?) -> Int? {
+func livingSpace(_ person: Person2?) -> Int? {
     return person?.residence?.rooms.map {$0.length * $0.width }.reduce(0, combine: +)
 }
 //: The parameter to *livingSpace* is declared *Optional*, but we can pass a non-Optional value
-let jed_space = livingSpace(jed) // nil (Or to be precise .None)
+let jed_space = livingSpace(jed) // nil (Or to be precise .none)
 
-let fi_space = livingSpace(fi) // Some(16) - but Xcode will just state 16, because it's mendacious.
+let fi_space = livingSpace(fi) // some(16) - but Xcode will just state 16, because it's mendacious.
 

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/contents.swift
@@ -140,7 +140,7 @@ Values passed to the function will be automatically *lifted* into the *Optional*
 This differs from our custom *Maybe* type, where auto-lifting does not occur.
 */
 func livingSpace(_ person: Person2?) -> Int? {
-    return person?.residence?.rooms.map {$0.length * $0.width }.reduce(0, combine: +)
+    return person?.residence?.rooms.map {$0.length * $0.width }.reduce(0, +)
 }
 //: The parameter to *livingSpace* is declared *Optional*, but we can pass a non-Optional value
 let jed_space = livingSpace(jed) // nil (Or to be precise .none)

--- a/Playgrounds/2b_Maybe_Type_Monad.playground/timeline.xctimeline
+++ b/Playgrounds/2b_Maybe_Type_Monad.playground/timeline.xctimeline
@@ -13,22 +13,22 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1504&amp;EndingColumnNumber=14&amp;EndingLineNumber=46&amp;StartingColumnNumber=5&amp;StartingLineNumber=46&amp;Timestamp=472930913.460819"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1504&amp;EndingColumnNumber=14&amp;EndingLineNumber=50&amp;StartingColumnNumber=5&amp;StartingLineNumber=50&amp;Timestamp=493195731.82926"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1570&amp;EndingColumnNumber=1&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=472930913.461119"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1570&amp;EndingColumnNumber=1&amp;EndingLineNumber=50&amp;StartingColumnNumber=1&amp;StartingLineNumber=50&amp;Timestamp=493195731.829392"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1496&amp;EndingColumnNumber=14&amp;EndingLineNumber=45&amp;StartingColumnNumber=5&amp;StartingLineNumber=45&amp;Timestamp=472930913.461409"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1496&amp;EndingColumnNumber=14&amp;EndingLineNumber=49&amp;StartingColumnNumber=5&amp;StartingLineNumber=49&amp;Timestamp=493195731.829518"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1562&amp;EndingColumnNumber=13&amp;EndingLineNumber=47&amp;StartingColumnNumber=5&amp;StartingLineNumber=47&amp;Timestamp=472930913.461791"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1562&amp;EndingColumnNumber=13&amp;EndingLineNumber=51&amp;StartingColumnNumber=5&amp;StartingLineNumber=51&amp;Timestamp=493195731.829644"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -48,12 +48,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1507&amp;EndingColumnNumber=14&amp;EndingLineNumber=45&amp;StartingColumnNumber=5&amp;StartingLineNumber=45&amp;Timestamp=472930913.462977"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1507&amp;EndingColumnNumber=14&amp;EndingLineNumber=49&amp;StartingColumnNumber=5&amp;StartingLineNumber=49&amp;Timestamp=493195731.830133"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1573&amp;EndingColumnNumber=13&amp;EndingLineNumber=47&amp;StartingColumnNumber=5&amp;StartingLineNumber=47&amp;Timestamp=472930913.46327"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1573&amp;EndingColumnNumber=13&amp;EndingLineNumber=51&amp;StartingColumnNumber=5&amp;StartingLineNumber=51&amp;Timestamp=493195731.830257"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -68,12 +68,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1509&amp;EndingColumnNumber=14&amp;EndingLineNumber=45&amp;StartingColumnNumber=5&amp;StartingLineNumber=45&amp;Timestamp=472930913.46418"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1509&amp;EndingColumnNumber=14&amp;EndingLineNumber=49&amp;StartingColumnNumber=5&amp;StartingLineNumber=49&amp;Timestamp=493195731.830624"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1575&amp;EndingColumnNumber=13&amp;EndingLineNumber=47&amp;StartingColumnNumber=5&amp;StartingLineNumber=47&amp;Timestamp=472930913.464473"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1575&amp;EndingColumnNumber=13&amp;EndingLineNumber=51&amp;StartingColumnNumber=5&amp;StartingLineNumber=51&amp;Timestamp=493195731.830747"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -88,22 +88,22 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1510&amp;EndingColumnNumber=14&amp;EndingLineNumber=44&amp;StartingColumnNumber=5&amp;StartingLineNumber=44&amp;Timestamp=472930913.465432"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1510&amp;EndingColumnNumber=14&amp;EndingLineNumber=44&amp;StartingColumnNumber=5&amp;StartingLineNumber=44&amp;Timestamp=493195731.831122"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1576&amp;EndingColumnNumber=13&amp;EndingLineNumber=46&amp;StartingColumnNumber=5&amp;StartingLineNumber=46&amp;Timestamp=472930913.465728"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1576&amp;EndingColumnNumber=13&amp;EndingLineNumber=50&amp;StartingColumnNumber=5&amp;StartingLineNumber=50&amp;Timestamp=493195731.831258"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1580&amp;EndingColumnNumber=13&amp;EndingLineNumber=46&amp;StartingColumnNumber=5&amp;StartingLineNumber=46&amp;Timestamp=472930913.466021"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1580&amp;EndingColumnNumber=13&amp;EndingLineNumber=50&amp;StartingColumnNumber=5&amp;StartingLineNumber=50&amp;Timestamp=493195731.831392"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1514&amp;EndingColumnNumber=14&amp;EndingLineNumber=44&amp;StartingColumnNumber=5&amp;StartingLineNumber=44&amp;Timestamp=472930913.466213"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1514&amp;EndingColumnNumber=14&amp;EndingLineNumber=44&amp;StartingColumnNumber=5&amp;StartingLineNumber=44&amp;Timestamp=493195731.831533"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
+++ b/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
@@ -1,5 +1,5 @@
 
-public func >>= <A,B>(x: A?, f: @noescape (A) -> B?) -> B? {
+public func >>= <A,B>(x: A?, f: (A) -> B?) -> B? {
     switch x {
     case .none : return .none
     case .some(let x) : return f(x)

--- a/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
+++ b/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
@@ -6,12 +6,12 @@ public func >>= <A,B>(x: A?, f: @noescape (A) -> B?) -> B? {
     }
 }
 
-public enum Maybe<T> : NilLiteralConvertible {
+public enum Maybe<T> : ExpressibleByNilLiteral {
     case none, some(T)
     
-    public init() { self = none }
-    public init(_ s: T) { self = some(s) }
-    public init(nilLiteral: ()) { self = none }
+    public init() { self = .none }
+    public init(_ s: T) { self = .some(s) }
+    public init(nilLiteral: ()) { self = .none }
     
     public func map<U>(_ f: (T) -> U) -> Maybe<U> {
         switch self {

--- a/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
+++ b/Playgrounds/3a_Optional_Madness.playground/Sources/SupportCode.swift
@@ -1,22 +1,22 @@
 
-public func >>= <A,B>(x: A?, @noescape f: A -> B?) -> B? {
+public func >>= <A,B>(x: A?, f: @noescape (A) -> B?) -> B? {
     switch x {
-    case .None : return .None
-    case .Some(let x) : return f(x)
+    case .none : return .none
+    case .some(let x) : return f(x)
     }
 }
 
 public enum Maybe<T> : NilLiteralConvertible {
-    case None, Some(T)
+    case none, some(T)
     
-    public init() { self = None }
-    public init(_ some: T) { self = Some(some) }
-    public init(nilLiteral: ()) { self = None }
+    public init() { self = none }
+    public init(_ s: T) { self = some(s) }
+    public init(nilLiteral: ()) { self = none }
     
-    public func map<U>(f: T -> U) -> Maybe<U> {
+    public func map<U>(_ f: (T) -> U) -> Maybe<U> {
         switch self {
-        case .None : return .None
-        case .Some(let x) : return .Some(f(x))
+        case .none : return .none
+        case .some(let x) : return .some(f(x))
         }
     }
 }
@@ -24,24 +24,24 @@ public enum Maybe<T> : NilLiteralConvertible {
 extension Maybe : CustomStringConvertible {
     public var description: String {
         switch self {
-        case .None : return "{None}"
-        case .Some(let x) : return "{Some \(x)}"
+        case .none : return "{none}"
+        case .some(let x) : return "{some \(x)}"
         }
     }
 }
 
 public func == <T: Equatable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .None) : return true
-    case let (.Some(x), .Some(y)) : return x == y
+    case (.none, .none) : return true
+    case let (.some(x), .some(y)) : return x == y
     default : return false
     }
 }
 
 public func < <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
     switch (lhs, rhs) {
-    case (.None, .Some) : return true
-    case let (.Some(x), .Some(y)) : return x < y
+    case (.none, .some) : return true
+    case let (.some(x), .some(y)) : return x < y
     default : return false
     }
 }
@@ -51,21 +51,21 @@ public func > <T: Comparable>(lhs: Maybe<T>, rhs: Maybe<T>) -> Bool {
 }
 
 
-public func map<A,B>(m: Maybe<A>, f: A -> B) -> Maybe<B> {
+public func map<A,B>(_ m: Maybe<A>, f: (A) -> B) -> Maybe<B> {
     switch m {
-    case .None : return .None
-    case .Some(let x) : return .Some(f(x))
+    case .none : return .none
+    case .some(let x) : return .some(f(x))
     }
 }
 
-public func pure<A>(x:A) -> Maybe<A> {
+public func pure<A>(_ x:A) -> Maybe<A> {
     return Maybe(x)
 }
 
 //infix operator >>= {associativity left}
-public func >>= <A,B> (m: Maybe<A>, f: A -> Maybe<B>) -> Maybe<B> {
+public func >>= <A,B> (m: Maybe<A>, f: (A) -> Maybe<B>) -> Maybe<B> {
     switch m {
-    case .None : return .None
-    case .Some(let m) : return f(m)
+    case .none : return .none
+    case .some(let m) : return f(m)
     }
 }

--- a/Playgrounds/3a_Optional_Madness.playground/contents.swift
+++ b/Playgrounds/3a_Optional_Madness.playground/contents.swift
@@ -30,7 +30,7 @@ All people have a name and they may, or may not own a **Pet**
 */
 let peeps = [Person(name: "Fred", pet: Pet(age: 10)),
              Person(name: "Jane", pet: Pet(age: 1)),
-             Person(name: "Eric", pet: .None)]
+             Person(name: "Eric", pet: .none)]
 
 /*:
 **The Problem**
@@ -63,9 +63,9 @@ Otherwise the types won't match; Swift *helpfully* wraps the **4** in an **Optio
 
 When *Eric* is filtered, the *types* and *values* of the expression are as follows:
 
-    Optional<Int>.None < Optional<Int>.Some(4)
+    Optional<Int>.none < Optional<Int>.some(4)
 
-**.None** is always less than **.Some**, therefore the expression returns *true*.
+**.none** is always less than **.some**, therefore the expression returns *true*.
 
 * * *
 
@@ -77,7 +77,7 @@ The code isn't as succinct, or as clear as the previous version, but, it does re
 */
 
 let p2 = peeps.filter {
-    if let p = $0.pet where p.age < 4 {
+    if let p = $0.pet, p.age < 4 {
         return true
     }
     return false
@@ -88,15 +88,15 @@ print(p2)
 **Another Alternative**
 
 The **maybe** function is taken from *Haskell*. The *first parameter* to the function is the default value
-which is used in case the value of the *second parameter* is **Optional.None**. The *third parameter* is the function to be applied.
+which is used in case the value of the *second parameter* is **Optional.none**. The *third parameter* is the function to be applied.
 
 It is similar to *map* for *Optionals*, but the *default parameter* allows the return value to be a non-optional value.
 */
 
-func maybe<A,B>(opt: A?, @autoclosure defaultValue: () -> B, @noescape f: A -> B) -> B {
+func maybe<A,B>(_ opt: A?, defaultValue: @autoclosure () -> B, f: @noescape (A) -> B) -> B {
     switch opt {
-    case .None : return defaultValue()
-    case .Some(let x) : return f(x)
+    case .none : return defaultValue()
+    case .some(let x) : return f(x)
     }
 }
 
@@ -115,7 +115,7 @@ print(p3)
 
 The next approach uses both *map* on **Optional** and the *nil coalescing operator*.
 It does exactly the same thing as the **maybe** function, however it's pretty difficult to read.
-The return value of *map* is *Optional<Bool>.None* when the *Pet* is *.None*.
+The return value of *map* is *Optional<Bool>.none* when the *Pet* is *.none*.
 The *nil coalescing operator* **??** unwraps the **Optional** value and returns it –
 if there's no associated value to unwrap, it returns the default value, in this case *'false'*.
 */
@@ -139,7 +139,7 @@ struct Person2 {
 extension Person2 : CustomStringConvertible {
     var description : String {
         switch pet {
-        case .Some(let p) : return "\(name) has a Pet aged: \(p.age)"
+        case .some(let p) : return "\(name) has a Pet aged: \(p.age)"
         default : return "\(name) has no pet"
         }
     }
@@ -147,7 +147,7 @@ extension Person2 : CustomStringConvertible {
 //: create an array of people, this time with **Maybe<Pet>** properties
 let peeps2 = [Person2(name: "Fred", pet: Maybe(Pet(age: 10))),
               Person2(name: "Jane", pet: Maybe(Pet(age: 1))),
-              Person2(name: "Eric", pet: .None)]
+              Person2(name: "Eric", pet: .none)]
 /*:
 A first attempt at filtering the Array might be as follows:
 
@@ -162,18 +162,18 @@ The reason is because the return type of the closure passed to filter is incorre
 A desperate technique to escape from type-checking purgatory could look like this:
 
     peeps2.filter { switch $0.pet {
-        case .Some(let pet) : return pet.age < 4
-        case .None : return false
+        case .some(let pet) : return pet.age < 4
+        case .none : return false
         }
     }
 
 That would work, but it's ugly as hell – which is where we're destined for writing code like that. 
 Thankfully, there's a way to avoid it and it requires the **maybe** function – this time implemented for the **Maybe** type.
 */
-func maybe<A,B>(opt: Maybe<A>, @autoclosure defaultValue: () -> B, @noescape f: A -> B) -> B {
+func maybe<A,B>(_ opt: Maybe<A>, defaultValue: @autoclosure () -> B, f: @noescape (A) -> B) -> B {
     switch opt {
-    case .None : return defaultValue()
-    case .Some(let x) : return f(x)
+    case .none : return defaultValue()
+    case .some(let x) : return f(x)
     }
 }
 //: By using the **maybe** function, the filter expression can be implemented in a reasonably sane fashion:

--- a/Playgrounds/3a_Optional_Madness.playground/contents.swift
+++ b/Playgrounds/3a_Optional_Madness.playground/contents.swift
@@ -1,6 +1,25 @@
 /*:
 ## When Optionals go Bad!
 
+Update for Swift 3: this section is no longer relevant in Swift 3 due to [SE-0121 "Remove Optional Comparison Operators"](https://github.com/apple/swift-evolution/blob/master/proposals/0121-remove-optional-comparison-operators.md).
+For educational purposes, we assume that there are still implementations of Optional Comparison Operators.
+*/
+func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+    switch (lhs, rhs) {
+    case (.none, .some) : return true
+    case let (.some(x), .some(y)) : return x < y
+    default : return false
+    }
+}
+
+func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+    switch (lhs, rhs) {
+    case (.some, .none) : return true
+    case let (.some(x), .some(y)) : return x > y
+    default : return false
+    }
+}
+/*:
 Presented below is an edge case where Optionals behave in such a way as to produce unexpected results.
 
 To demonstrate this, we'll use a **Pet** struct that has one property *age*.
@@ -93,7 +112,7 @@ which is used in case the value of the *second parameter* is **Optional.none**. 
 It is similar to *map* for *Optionals*, but the *default parameter* allows the return value to be a non-optional value.
 */
 
-func maybe<A,B>(_ opt: A?, defaultValue: @autoclosure () -> B, f: @noescape (A) -> B) -> B {
+func maybe<A,B>(_ opt: A?, defaultValue: @autoclosure () -> B, f: (A) -> B) -> B {
     switch opt {
     case .none : return defaultValue()
     case .some(let x) : return f(x)
@@ -170,7 +189,7 @@ A desperate technique to escape from type-checking purgatory could look like thi
 That would work, but it's ugly as hell – which is where we're destined for writing code like that. 
 Thankfully, there's a way to avoid it and it requires the **maybe** function – this time implemented for the **Maybe** type.
 */
-func maybe<A,B>(_ opt: Maybe<A>, defaultValue: @autoclosure () -> B, f: @noescape (A) -> B) -> B {
+func maybe<A,B>(_ opt: Maybe<A>, defaultValue: @autoclosure () -> B, f: (A) -> B) -> B {
     switch opt {
     case .none : return defaultValue()
     case .some(let x) : return f(x)

--- a/Playgrounds/3a_Optional_Madness.playground/timeline.xctimeline
+++ b/Playgrounds/3a_Optional_Madness.playground/timeline.xctimeline
@@ -3,22 +3,22 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=2&amp;CharacterRangeLoc=3850&amp;EndingColumnNumber=3&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491664207.517329"
+         documentLocation = "#CharacterRangeLen=2&amp;CharacterRangeLoc=3840&amp;EndingColumnNumber=3&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=493542843.356059"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4474&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=491664207.517567"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4464&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=493542843.356234"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=2396&amp;EndingColumnNumber=2&amp;EndingLineNumber=41&amp;StartingColumnNumber=1&amp;StartingLineNumber=41&amp;Timestamp=472935415.862024"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=2396&amp;EndingColumnNumber=2&amp;EndingLineNumber=41&amp;StartingColumnNumber=1&amp;StartingLineNumber=41&amp;Timestamp=493542843.356372"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4474&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=491664207.517866"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4464&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=493542843.356504"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -113,22 +113,22 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=134&amp;CharacterRangeLoc=1902&amp;EndingColumnNumber=67&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472935415.868061"
+         documentLocation = "#CharacterRangeLen=134&amp;CharacterRangeLoc=1902&amp;EndingColumnNumber=67&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=493542843.358863"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6644&amp;EndingColumnNumber=67&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491664207.521196"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6624&amp;EndingColumnNumber=67&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=493542843.358991"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=66&amp;CharacterRangeLoc=1879&amp;EndingColumnNumber=67&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472935415.868683"
+         documentLocation = "#CharacterRangeLen=66&amp;CharacterRangeLoc=1879&amp;EndingColumnNumber=67&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=493542843.359115"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=66&amp;CharacterRangeLoc=1899&amp;EndingColumnNumber=67&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472935415.868998"
+         documentLocation = "#CharacterRangeLen=66&amp;CharacterRangeLoc=1899&amp;EndingColumnNumber=67&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=493542843.35924"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -153,7 +153,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=64&amp;CharacterRangeLoc=1852&amp;EndingColumnNumber=65&amp;EndingLineNumber=70&amp;StartingColumnNumber=1&amp;StartingLineNumber=70&amp;Timestamp=472935415.870507"
+         documentLocation = "#CharacterRangeLen=64&amp;CharacterRangeLoc=1852&amp;EndingColumnNumber=65&amp;EndingLineNumber=70&amp;StartingColumnNumber=1&amp;StartingLineNumber=70&amp;Timestamp=493542843.359958"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/3a_Optional_Madness.playground/timeline.xctimeline
+++ b/Playgrounds/3a_Optional_Madness.playground/timeline.xctimeline
@@ -3,12 +3,12 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=2&amp;CharacterRangeLoc=3865&amp;EndingColumnNumber=3&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=472935415.861359"
+         documentLocation = "#CharacterRangeLen=2&amp;CharacterRangeLoc=3850&amp;EndingColumnNumber=3&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491664207.517329"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4489&amp;EndingColumnNumber=3&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=472935415.861717"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4474&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=491664207.517567"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -18,7 +18,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4489&amp;EndingColumnNumber=3&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=472935415.862328"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=4474&amp;EndingColumnNumber=10&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=491664207.517866"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -118,7 +118,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6669&amp;EndingColumnNumber=67&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=472936100.608695"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6644&amp;EndingColumnNumber=67&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491664207.521196"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Contents.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Contents.swift
@@ -17,20 +17,20 @@ let dict = [1:[2:[3:[4:[5:"Hello!"]]]]]
 let a:String?
 
 switch dict[1] {
-case .None : a = .None
-case .Some(let d) :
+case .none : a = .none
+case .some(let d) :
     switch d[2] {
-    case .None : a = .None
-    case .Some(let d) :
+    case .none : a = .none
+    case .some(let d) :
         switch d[3] {
-        case .None : a = .None
-        case .Some(let d) :
+        case .none : a = .none
+        case .some(let d) :
             switch d[4] {
-            case .None : a = .None
-            case .Some(let d) :
+            case .none : a = .none
+            case .some(let d) :
                 switch d[5] {
-                case .None : a = .None
-                case .Some(let x) : a = x
+                case .none : a = .none
+                case .some(let x) : a = x
                 }
             }
         }
@@ -53,10 +53,10 @@ If we define the bind operator **>>=** for **Optionals**, it's easy to see the s
 */
 infix operator >>= {associativity left}
 
-func >>= <A,B>(x: A?, f: A -> B?) -> B? {
+func >>= <A,B>(x: A?, f: (A) -> B?) -> B? {
     switch x {
-    case .None : return .None
-    case .Some(let x) : return f(x)
+    case .none : return .none
+    case .some(let x) : return f(x)
     }
 }
 //: The monadic nature of *Optional chaining*
@@ -82,10 +82,10 @@ As **if let** is a statement, not an expression, a variable must be declared fir
 */
 let ifLetBind:String?
 
-if let a = dict[1], b = a[2], c = b[3], d = c[4], e = d[5] {
+if let a = dict[1], let b = a[2], let c = b[3], let d = c[4], let e = d[5] {
     ifLetBind = e
 } else {
-    ifLetBind = .None
+    ifLetBind = .none
 }
 
 ifLetBind
@@ -100,7 +100,7 @@ For example, the following is **not** the equivalent of monadic bind, because th
 let x = Optional(1)
 let y = Optional(2)
 
-if let a = x, b = y {
+if let a = x, let b = y {
     a + b
 }
 /*:
@@ -153,7 +153,7 @@ str.characters.first.flatMap { String($0).toInt() }
 
 str.characters.first >>= { String($0).toInt() }
 
-if let c = str.characters.first, i = String(c).toInt() {
+if let c = str.characters.first, let i = String(c).toInt() {
     i
 }
 /*:
@@ -190,17 +190,17 @@ Using **if let**, it's possible to cast the **Optional<AnyObject>** to **JSON** 
 
 We can then subscript into **j** within the **if let** statement to access the JSON values
 (casting to the correct type as we do so). As later bindings depend upon the previous variable **j**, this is a monadic bind operation.
-Finally, if the **if let** statement succeeds, create and return the **Person** type, otherwise, return **.None**.
+Finally, if the **if let** statement succeeds, create and return the **Person** type, otherwise, return **.none**.
 */
-func parseJSON(json:AnyObject?) -> Person? {
+func parseJSON(_ json:AnyObject?) -> Person? {
   if let j = json as? JSON,
-         name = j["name"] as? String,
-         job = j["job"] as? String,
-         year_of_birth = j["year_of_birth"] as? Int
+         let name = j["name"] as? String,
+         let job = j["job"] as? String,
+         let year_of_birth = j["year_of_birth"] as? Int
   {
     return Person(name:name, job:job, birthYear:year_of_birth)
   } else {
-    return .None
+    return .none
   }
 }
 /*:

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Contents.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Contents.swift
@@ -51,7 +51,11 @@ The pattern matching boiler plate code has been abstracted away inside the magic
 It turns out that *Optional chaining* with **?** is monadic bind that is restricted to methods and subscript operations.
 If we define the bind operator **>>=** for **Optionals**, it's easy to see the similarity.
 */
-infix operator >>= {associativity left}
+precedencegroup BindPrecedence {
+	associativity: left
+	higherThan: AssignmentPrecedence
+}
+infix operator >>= : BindPrecedence
 
 func >>= <A,B>(x: A?, f: (A) -> B?) -> B? {
     switch x {
@@ -182,7 +186,7 @@ The first thing to do is to define a **typealias** to represent a JSON dictionar
 using the **JSONFromFile** function.
 */
 typealias JSON = [String:AnyObject]
-let json: AnyObject? = JSONFromFile("person")
+let json: Any? = JSONFromFile("person")
 /*:
 The next task is to parse the JSON data and initialize a **Person**.
 To do so, we can define a function that takes an **Optional<AnyObject>** and returns an **<Optional<Person>**.
@@ -192,7 +196,7 @@ We can then subscript into **j** within the **if let** statement to access the J
 (casting to the correct type as we do so). As later bindings depend upon the previous variable **j**, this is a monadic bind operation.
 Finally, if the **if let** statement succeeds, create and return the **Person** type, otherwise, return **.none**.
 */
-func parseJSON(_ json:AnyObject?) -> Person? {
+func parseJSON(_ json:Any?) -> Person? {
   if let j = json as? JSON,
          let name = j["name"] as? String,
          let job = j["job"] as? String,

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-public func JSONFromFile(_ file: String) -> AnyObject? {
-  return Bundle.main.path(forResource: file, ofType: "json").flatMap { p in
-    (try? Data(contentsOf: URL(fileURLWithPath: p))).flatMap { data in
-      try! JSONSerialization.jsonObject(with: data, options: [])
+public func JSONFromFile(_ file: String) -> Any? {
+	return Bundle.main.path(forResource: file, ofType: "json").flatMap { (p: String) -> Any? in
+		let data = try! Data(contentsOf: URL(fileURLWithPath: p))
+		return try! JSONSerialization.jsonObject(with: data, options: [])
     }
-  }
 }
 
 

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public func JSONFromFile(_ file: String) -> AnyObject? {
-  return Bundle.main.pathForResource(file, ofType: "json").flatMap { p in
+  return Bundle.main.path(forResource: file, ofType: "json").flatMap { p in
     (try? Data(contentsOf: URL(fileURLWithPath: p))).flatMap { data in
       try! JSONSerialization.jsonObject(with: data, options: [])
     }

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public func JSONFromFile(file: String) -> AnyObject? {
-  return NSBundle.mainBundle().pathForResource(file, ofType: "json").flatMap { p in
-    NSData(contentsOfFile: p).flatMap { data in
-      try! NSJSONSerialization.JSONObjectWithData(data, options: [])
+public func JSONFromFile(_ file: String) -> AnyObject? {
+  return Bundle.main.pathForResource(file, ofType: "json").flatMap { p in
+    (try? Data(contentsOf: URL(fileURLWithPath: p))).flatMap { data in
+      try! JSONSerialization.jsonObject(with: data, options: [])
     }
   }
 }
@@ -29,9 +29,16 @@ public struct Person: CustomStringConvertible {
 /*
 A curried constructor function to use with the <*> operator. See below.
 */
+public typealias Name = String
+public typealias Job = String
+public typealias BirthYear = Int
 extension Person {
-  public static func create(name:String)(job:String)(birthYear:Int) -> Person {
-    return Person(name:name, job:job, birthYear:birthYear)
+  public static func create(_ name:Name) -> (Job) -> (BirthYear) -> Person {
+	return { job in
+		return { birthYear in
+			return Person(name:name, job:job, birthYear:birthYear)
+		}
+	}
   }
 }
 
@@ -42,9 +49,9 @@ If both function and value are not nil, then apply the function to the value
 */
 infix operator <*> { associativity left precedence 130 }
 
-public func <*> <A,B>(f:(A -> B)?, x:A?) -> B? {
-  if let f = f, x = x {
+public func <*> <A,B>(f:((A) -> B)?, x:A?) -> B? {
+  if let f = f, let x = x {
     return f(x)
   }
-  return .None
+  return .none
 }

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/Sources/SupportCode.swift
@@ -47,7 +47,11 @@ Apply operator for Optionals:
 Takes an Optional function and an Optional value,
 If both function and value are not nil, then apply the function to the value
 */
-infix operator <*> { associativity left precedence 130 }
+precedencegroup ApplyPrecedence {
+	associativity: left
+	higherThan: ComparisonPrecedence
+}
+infix operator <*> : ApplyPrecedence
 
 public func <*> <A,B>(f:((A) -> B)?, x:A?) -> B? {
   if let f = f, let x = x {

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/timeline.xctimeline
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/timeline.xctimeline
@@ -3,12 +3,12 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=2852&amp;EndingColumnNumber=20&amp;EndingLineNumber=72&amp;StartingColumnNumber=15&amp;StartingLineNumber=72&amp;Timestamp=491664326.334446"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=2938&amp;EndingColumnNumber=20&amp;EndingLineNumber=76&amp;StartingColumnNumber=15&amp;StartingLineNumber=76&amp;Timestamp=493543159.609251"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=24&amp;EndingLineNumber=146&amp;StartingColumnNumber=19&amp;StartingLineNumber=146&amp;Timestamp=491666841.910627"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8615&amp;EndingColumnNumber=24&amp;EndingLineNumber=150&amp;StartingColumnNumber=19&amp;StartingLineNumber=150&amp;Timestamp=493545425.62066"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -23,12 +23,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1900&amp;EndingColumnNumber=24&amp;EndingLineNumber=68&amp;StartingColumnNumber=19&amp;StartingLineNumber=68&amp;Timestamp=491664326.335014"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1986&amp;EndingColumnNumber=24&amp;EndingLineNumber=72&amp;StartingColumnNumber=19&amp;StartingLineNumber=72&amp;Timestamp=493543159.610169"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=1926&amp;EndingColumnNumber=24&amp;EndingLineNumber=45&amp;StartingColumnNumber=1&amp;StartingLineNumber=45&amp;Timestamp=491664326.335144"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=2012&amp;EndingColumnNumber=24&amp;EndingLineNumber=45&amp;StartingColumnNumber=1&amp;StartingLineNumber=45&amp;Timestamp=493543159.610387"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -38,97 +38,97 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1394&amp;EndingColumnNumber=6&amp;EndingLineNumber=58&amp;StartingColumnNumber=5&amp;StartingLineNumber=58&amp;Timestamp=491664326.335399"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1394&amp;EndingColumnNumber=6&amp;EndingLineNumber=62&amp;StartingColumnNumber=5&amp;StartingLineNumber=62&amp;Timestamp=493543159.610811"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1805&amp;EndingColumnNumber=27&amp;EndingLineNumber=63&amp;StartingColumnNumber=17&amp;StartingLineNumber=63&amp;Timestamp=491664326.335527"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1891&amp;EndingColumnNumber=27&amp;EndingLineNumber=67&amp;StartingColumnNumber=17&amp;StartingLineNumber=67&amp;Timestamp=493543159.61103"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=174&amp;CharacterRangeLoc=1399&amp;EndingColumnNumber=19&amp;EndingLineNumber=59&amp;StartingColumnNumber=1&amp;StartingLineNumber=59&amp;Timestamp=491664326.335662"
+         documentLocation = "#CharacterRangeLen=174&amp;CharacterRangeLoc=1399&amp;EndingColumnNumber=19&amp;EndingLineNumber=63&amp;StartingColumnNumber=1&amp;StartingLineNumber=63&amp;Timestamp=493543159.611245"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1595&amp;EndingColumnNumber=31&amp;EndingLineNumber=60&amp;StartingColumnNumber=21&amp;StartingLineNumber=60&amp;Timestamp=491664326.3358"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1595&amp;EndingColumnNumber=31&amp;EndingLineNumber=64&amp;StartingColumnNumber=21&amp;StartingLineNumber=64&amp;Timestamp=493543159.611458"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3927&amp;EndingColumnNumber=31&amp;EndingLineNumber=103&amp;StartingColumnNumber=21&amp;StartingLineNumber=103&amp;Timestamp=491664373.967108"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4013&amp;EndingColumnNumber=31&amp;EndingLineNumber=107&amp;StartingColumnNumber=21&amp;StartingLineNumber=107&amp;Timestamp=493543159.611665"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4020&amp;EndingColumnNumber=19&amp;EndingLineNumber=108&amp;StartingColumnNumber=1&amp;StartingLineNumber=108&amp;Timestamp=491664373.967286"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4106&amp;EndingColumnNumber=19&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=493543159.611877"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=4060&amp;EndingColumnNumber=31&amp;EndingLineNumber=110&amp;StartingColumnNumber=21&amp;StartingLineNumber=110&amp;Timestamp=491664373.967467"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=4146&amp;EndingColumnNumber=31&amp;EndingLineNumber=114&amp;StartingColumnNumber=21&amp;StartingLineNumber=114&amp;Timestamp=493543159.612089"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=4090&amp;EndingColumnNumber=27&amp;EndingLineNumber=112&amp;StartingColumnNumber=17&amp;StartingLineNumber=112&amp;Timestamp=491664373.967581"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=4176&amp;EndingColumnNumber=27&amp;EndingLineNumber=116&amp;StartingColumnNumber=17&amp;StartingLineNumber=116&amp;Timestamp=493543159.612301"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1749&amp;EndingColumnNumber=13&amp;EndingLineNumber=86&amp;StartingColumnNumber=5&amp;StartingLineNumber=86&amp;Timestamp=491664326.336399"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1749&amp;EndingColumnNumber=13&amp;EndingLineNumber=90&amp;StartingColumnNumber=5&amp;StartingLineNumber=90&amp;Timestamp=493543159.61251"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=43&amp;EndingLineNumber=122&amp;StartingColumnNumber=33&amp;StartingLineNumber=122&amp;Timestamp=491664373.967806"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4621&amp;EndingColumnNumber=43&amp;EndingLineNumber=126&amp;StartingColumnNumber=33&amp;StartingLineNumber=126&amp;Timestamp=493543159.612721"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=39&amp;EndingLineNumber=122&amp;StartingColumnNumber=29&amp;StartingLineNumber=122&amp;Timestamp=491664373.967919"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4621&amp;EndingColumnNumber=39&amp;EndingLineNumber=126&amp;StartingColumnNumber=29&amp;StartingLineNumber=126&amp;Timestamp=493543159.612943"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=6&amp;EndingLineNumber=122&amp;StartingColumnNumber=5&amp;StartingLineNumber=122&amp;Timestamp=491664373.968025"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4621&amp;EndingColumnNumber=6&amp;EndingLineNumber=126&amp;StartingColumnNumber=5&amp;StartingLineNumber=126&amp;Timestamp=493543159.613148"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=20&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=491664373.968132"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4621&amp;EndingColumnNumber=20&amp;EndingLineNumber=126&amp;StartingColumnNumber=1&amp;StartingLineNumber=126&amp;Timestamp=493543159.613352"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5316&amp;EndingColumnNumber=43&amp;EndingLineNumber=146&amp;StartingColumnNumber=25&amp;StartingLineNumber=146&amp;Timestamp=491664373.968238"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5402&amp;EndingColumnNumber=43&amp;EndingLineNumber=150&amp;StartingColumnNumber=25&amp;StartingLineNumber=150&amp;Timestamp=493543159.613561"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5355&amp;EndingColumnNumber=36&amp;EndingLineNumber=148&amp;StartingColumnNumber=18&amp;StartingLineNumber=147&amp;Timestamp=491664373.968344"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5441&amp;EndingColumnNumber=36&amp;EndingLineNumber=152&amp;StartingColumnNumber=18&amp;StartingLineNumber=151&amp;Timestamp=493543159.613775"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=51&amp;EndingLineNumber=235&amp;StartingColumnNumber=36&amp;StartingLineNumber=235&amp;Timestamp=491666841.913152"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8615&amp;EndingColumnNumber=51&amp;EndingLineNumber=239&amp;StartingColumnNumber=36&amp;StartingLineNumber=239&amp;Timestamp=493545425.624584"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=100&amp;EndingLineNumber=235&amp;StartingColumnNumber=83&amp;StartingLineNumber=235&amp;Timestamp=491666841.913273"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8615&amp;EndingColumnNumber=100&amp;EndingLineNumber=239&amp;StartingColumnNumber=83&amp;StartingLineNumber=239&amp;Timestamp=493545425.62476"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5432&amp;EndingColumnNumber=6&amp;EndingLineNumber=151&amp;StartingColumnNumber=5&amp;StartingLineNumber=151&amp;Timestamp=491664373.968677"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5518&amp;EndingColumnNumber=6&amp;EndingLineNumber=155&amp;StartingColumnNumber=5&amp;StartingLineNumber=155&amp;Timestamp=493543159.614392"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=8509&amp;EndingColumnNumber=31&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=491666841.913511"
+         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=8583&amp;EndingColumnNumber=31&amp;EndingLineNumber=236&amp;StartingColumnNumber=1&amp;StartingLineNumber=236&amp;Timestamp=493545425.625144"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -153,63 +153,63 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1117&amp;EndingColumnNumber=24&amp;EndingLineNumber=57&amp;StartingColumnNumber=19&amp;StartingLineNumber=57&amp;Timestamp=491664326.338149"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1117&amp;EndingColumnNumber=24&amp;EndingLineNumber=61&amp;StartingColumnNumber=19&amp;StartingLineNumber=61&amp;Timestamp=493543159.615622"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1168&amp;EndingColumnNumber=40&amp;EndingLineNumber=61&amp;StartingColumnNumber=22&amp;StartingLineNumber=61&amp;Timestamp=491664326.338264"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1168&amp;EndingColumnNumber=40&amp;EndingLineNumber=65&amp;StartingColumnNumber=22&amp;StartingLineNumber=65&amp;Timestamp=493543159.615829"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1207&amp;EndingColumnNumber=36&amp;EndingLineNumber=63&amp;StartingColumnNumber=18&amp;StartingLineNumber=63&amp;Timestamp=491664326.338378"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1207&amp;EndingColumnNumber=36&amp;EndingLineNumber=67&amp;StartingColumnNumber=18&amp;StartingLineNumber=67&amp;Timestamp=493543159.616036"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1280&amp;EndingColumnNumber=6&amp;EndingLineNumber=66&amp;StartingColumnNumber=5&amp;StartingLineNumber=66&amp;Timestamp=491664326.338492"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1280&amp;EndingColumnNumber=6&amp;EndingLineNumber=70&amp;StartingColumnNumber=5&amp;StartingLineNumber=70&amp;Timestamp=493543159.616247"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=1375&amp;EndingColumnNumber=31&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491664326.338606"
+         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=1375&amp;EndingColumnNumber=31&amp;EndingLineNumber=78&amp;StartingColumnNumber=1&amp;StartingLineNumber=78&amp;Timestamp=493543159.616455"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6246&amp;EndingColumnNumber=91&amp;EndingLineNumber=176&amp;StartingColumnNumber=3&amp;StartingLineNumber=176&amp;Timestamp=491664373.969792"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6332&amp;EndingColumnNumber=91&amp;EndingLineNumber=180&amp;StartingColumnNumber=3&amp;StartingLineNumber=180&amp;Timestamp=493543159.616664"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=7306&amp;EndingColumnNumber=14&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491664373.969898"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=7380&amp;EndingColumnNumber=14&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=493545425.627332"
          lockedSize = "{216, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7914&amp;EndingColumnNumber=17&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491664373.970009"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7988&amp;EndingColumnNumber=17&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=493545425.627545"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7321&amp;EndingColumnNumber=17&amp;EndingLineNumber=203&amp;StartingColumnNumber=1&amp;StartingLineNumber=203&amp;Timestamp=491664373.970117"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7395&amp;EndingColumnNumber=17&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=493545425.627759"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8093&amp;EndingColumnNumber=17&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491666839.55827"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8167&amp;EndingColumnNumber=17&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=493545425.627964"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1818&amp;EndingColumnNumber=16&amp;EndingLineNumber=90&amp;StartingColumnNumber=1&amp;StartingLineNumber=90&amp;Timestamp=491664326.33931"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1904&amp;EndingColumnNumber=16&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=493543159.617732"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2019&amp;EndingColumnNumber=17&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491664326.339424"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2105&amp;EndingColumnNumber=17&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=493543159.617938"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/timeline.xctimeline
+++ b/Playgrounds/4a_Three_Binds_Are_Better_Than_One.playground/timeline.xctimeline
@@ -3,213 +3,213 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=2848&amp;EndingColumnNumber=20&amp;EndingLineNumber=72&amp;StartingColumnNumber=15&amp;StartingLineNumber=72&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=2852&amp;EndingColumnNumber=20&amp;EndingLineNumber=72&amp;StartingColumnNumber=15&amp;StartingLineNumber=72&amp;Timestamp=491664326.334446"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8501&amp;EndingColumnNumber=24&amp;EndingLineNumber=146&amp;StartingColumnNumber=19&amp;StartingLineNumber=146&amp;Timestamp=453803028.553528"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=24&amp;EndingLineNumber=146&amp;StartingColumnNumber=19&amp;StartingLineNumber=146&amp;Timestamp=491666841.910627"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=793&amp;EndingColumnNumber=42&amp;EndingLineNumber=18&amp;StartingColumnNumber=41&amp;StartingLineNumber=18&amp;Timestamp=451578176.123416"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=797&amp;EndingColumnNumber=42&amp;EndingLineNumber=18&amp;StartingColumnNumber=41&amp;StartingLineNumber=18&amp;Timestamp=491664326.334756"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1070&amp;EndingColumnNumber=20&amp;EndingLineNumber=40&amp;StartingColumnNumber=15&amp;StartingLineNumber=40&amp;Timestamp=451578426.912033"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1074&amp;EndingColumnNumber=20&amp;EndingLineNumber=40&amp;StartingColumnNumber=15&amp;StartingLineNumber=40&amp;Timestamp=491664326.334886"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1896&amp;EndingColumnNumber=24&amp;EndingLineNumber=68&amp;StartingColumnNumber=19&amp;StartingLineNumber=68&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1900&amp;EndingColumnNumber=24&amp;EndingLineNumber=68&amp;StartingColumnNumber=19&amp;StartingLineNumber=68&amp;Timestamp=491664326.335014"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=1922&amp;EndingColumnNumber=24&amp;EndingLineNumber=45&amp;StartingColumnNumber=1&amp;StartingLineNumber=45&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=1926&amp;EndingColumnNumber=24&amp;EndingLineNumber=45&amp;StartingColumnNumber=1&amp;StartingLineNumber=45&amp;Timestamp=491664326.335144"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1214&amp;EndingColumnNumber=2&amp;EndingLineNumber=36&amp;StartingColumnNumber=2&amp;StartingLineNumber=36&amp;Timestamp=451578499.408528"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1218&amp;EndingColumnNumber=2&amp;EndingLineNumber=36&amp;StartingColumnNumber=2&amp;StartingLineNumber=36&amp;Timestamp=491664326.335273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1390&amp;EndingColumnNumber=6&amp;EndingLineNumber=58&amp;StartingColumnNumber=5&amp;StartingLineNumber=58&amp;Timestamp=451578897.352138"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1394&amp;EndingColumnNumber=6&amp;EndingLineNumber=58&amp;StartingColumnNumber=5&amp;StartingLineNumber=58&amp;Timestamp=491664326.335399"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1801&amp;EndingColumnNumber=27&amp;EndingLineNumber=63&amp;StartingColumnNumber=17&amp;StartingLineNumber=63&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1805&amp;EndingColumnNumber=27&amp;EndingLineNumber=63&amp;StartingColumnNumber=17&amp;StartingLineNumber=63&amp;Timestamp=491664326.335527"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=174&amp;CharacterRangeLoc=1395&amp;EndingColumnNumber=19&amp;EndingLineNumber=59&amp;StartingColumnNumber=1&amp;StartingLineNumber=59&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=174&amp;CharacterRangeLoc=1399&amp;EndingColumnNumber=19&amp;EndingLineNumber=59&amp;StartingColumnNumber=1&amp;StartingLineNumber=59&amp;Timestamp=491664326.335662"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1591&amp;EndingColumnNumber=31&amp;EndingLineNumber=60&amp;StartingColumnNumber=21&amp;StartingLineNumber=60&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1595&amp;EndingColumnNumber=31&amp;EndingLineNumber=60&amp;StartingColumnNumber=21&amp;StartingLineNumber=60&amp;Timestamp=491664326.3358"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3903&amp;EndingColumnNumber=31&amp;EndingLineNumber=103&amp;StartingColumnNumber=21&amp;StartingLineNumber=103&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3927&amp;EndingColumnNumber=31&amp;EndingLineNumber=103&amp;StartingColumnNumber=21&amp;StartingLineNumber=103&amp;Timestamp=491664373.967108"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=3996&amp;EndingColumnNumber=19&amp;EndingLineNumber=108&amp;StartingColumnNumber=1&amp;StartingLineNumber=108&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4020&amp;EndingColumnNumber=19&amp;EndingLineNumber=108&amp;StartingColumnNumber=1&amp;StartingLineNumber=108&amp;Timestamp=491664373.967286"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=4036&amp;EndingColumnNumber=31&amp;EndingLineNumber=110&amp;StartingColumnNumber=21&amp;StartingLineNumber=110&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=4060&amp;EndingColumnNumber=31&amp;EndingLineNumber=110&amp;StartingColumnNumber=21&amp;StartingLineNumber=110&amp;Timestamp=491664373.967467"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=4066&amp;EndingColumnNumber=27&amp;EndingLineNumber=112&amp;StartingColumnNumber=17&amp;StartingLineNumber=112&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=4090&amp;EndingColumnNumber=27&amp;EndingLineNumber=112&amp;StartingColumnNumber=17&amp;StartingLineNumber=112&amp;Timestamp=491664373.967581"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1745&amp;EndingColumnNumber=13&amp;EndingLineNumber=86&amp;StartingColumnNumber=5&amp;StartingLineNumber=86&amp;Timestamp=451580888.805055"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1749&amp;EndingColumnNumber=13&amp;EndingLineNumber=86&amp;StartingColumnNumber=5&amp;StartingLineNumber=86&amp;Timestamp=491664326.336399"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4511&amp;EndingColumnNumber=43&amp;EndingLineNumber=122&amp;StartingColumnNumber=33&amp;StartingLineNumber=122&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=43&amp;EndingLineNumber=122&amp;StartingColumnNumber=33&amp;StartingLineNumber=122&amp;Timestamp=491664373.967806"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4511&amp;EndingColumnNumber=39&amp;EndingLineNumber=122&amp;StartingColumnNumber=29&amp;StartingLineNumber=122&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=39&amp;EndingLineNumber=122&amp;StartingColumnNumber=29&amp;StartingLineNumber=122&amp;Timestamp=491664373.967919"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4511&amp;EndingColumnNumber=6&amp;EndingLineNumber=122&amp;StartingColumnNumber=5&amp;StartingLineNumber=122&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=6&amp;EndingLineNumber=122&amp;StartingColumnNumber=5&amp;StartingLineNumber=122&amp;Timestamp=491664373.968025"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4511&amp;EndingColumnNumber=20&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=20&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=491664373.968132"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5292&amp;EndingColumnNumber=43&amp;EndingLineNumber=146&amp;StartingColumnNumber=25&amp;StartingLineNumber=146&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5316&amp;EndingColumnNumber=43&amp;EndingLineNumber=146&amp;StartingColumnNumber=25&amp;StartingLineNumber=146&amp;Timestamp=491664373.968238"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5331&amp;EndingColumnNumber=36&amp;EndingLineNumber=148&amp;StartingColumnNumber=18&amp;StartingLineNumber=147&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=5355&amp;EndingColumnNumber=36&amp;EndingLineNumber=148&amp;StartingColumnNumber=18&amp;StartingLineNumber=147&amp;Timestamp=491664373.968344"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8501&amp;EndingColumnNumber=51&amp;EndingLineNumber=235&amp;StartingColumnNumber=36&amp;StartingLineNumber=235&amp;Timestamp=453803028.559715"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=51&amp;EndingLineNumber=235&amp;StartingColumnNumber=36&amp;StartingLineNumber=235&amp;Timestamp=491666841.913152"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8501&amp;EndingColumnNumber=100&amp;EndingLineNumber=235&amp;StartingColumnNumber=83&amp;StartingLineNumber=235&amp;Timestamp=453803028.56004"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8541&amp;EndingColumnNumber=100&amp;EndingLineNumber=235&amp;StartingColumnNumber=83&amp;StartingLineNumber=235&amp;Timestamp=491666841.913273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5404&amp;EndingColumnNumber=6&amp;EndingLineNumber=151&amp;StartingColumnNumber=5&amp;StartingLineNumber=151&amp;Timestamp=453767451.957567"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5432&amp;EndingColumnNumber=6&amp;EndingLineNumber=151&amp;StartingColumnNumber=5&amp;StartingLineNumber=151&amp;Timestamp=491664373.968677"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=8469&amp;EndingColumnNumber=31&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=453803028.560775"
+         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=8509&amp;EndingColumnNumber=31&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=491666841.913511"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=521&amp;EndingColumnNumber=2&amp;EndingLineNumber=24&amp;StartingColumnNumber=1&amp;StartingLineNumber=24&amp;Timestamp=451576722.924583"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=525&amp;EndingColumnNumber=2&amp;EndingLineNumber=24&amp;StartingColumnNumber=1&amp;StartingLineNumber=24&amp;Timestamp=491664326.337691"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=524&amp;EndingColumnNumber=24&amp;EndingLineNumber=26&amp;StartingColumnNumber=1&amp;StartingLineNumber=26&amp;Timestamp=451576770.506406"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=528&amp;EndingColumnNumber=24&amp;EndingLineNumber=26&amp;StartingColumnNumber=1&amp;StartingLineNumber=26&amp;Timestamp=491664326.337806"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=931&amp;EndingColumnNumber=10&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=453767726.229771"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=935&amp;EndingColumnNumber=10&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=491664326.33792"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1009&amp;EndingColumnNumber=10&amp;EndingLineNumber=52&amp;StartingColumnNumber=5&amp;StartingLineNumber=52&amp;Timestamp=451578299.482266"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1013&amp;EndingColumnNumber=10&amp;EndingLineNumber=52&amp;StartingColumnNumber=5&amp;StartingLineNumber=52&amp;Timestamp=491664326.338034"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1113&amp;EndingColumnNumber=24&amp;EndingLineNumber=57&amp;StartingColumnNumber=19&amp;StartingLineNumber=57&amp;Timestamp=451578426.912033"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1117&amp;EndingColumnNumber=24&amp;EndingLineNumber=57&amp;StartingColumnNumber=19&amp;StartingLineNumber=57&amp;Timestamp=491664326.338149"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1164&amp;EndingColumnNumber=40&amp;EndingLineNumber=61&amp;StartingColumnNumber=22&amp;StartingLineNumber=61&amp;Timestamp=451578499.408528"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1168&amp;EndingColumnNumber=40&amp;EndingLineNumber=61&amp;StartingColumnNumber=22&amp;StartingLineNumber=61&amp;Timestamp=491664326.338264"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1203&amp;EndingColumnNumber=36&amp;EndingLineNumber=63&amp;StartingColumnNumber=18&amp;StartingLineNumber=63&amp;Timestamp=451578499.408528"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1207&amp;EndingColumnNumber=36&amp;EndingLineNumber=63&amp;StartingColumnNumber=18&amp;StartingLineNumber=63&amp;Timestamp=491664326.338378"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1276&amp;EndingColumnNumber=6&amp;EndingLineNumber=66&amp;StartingColumnNumber=5&amp;StartingLineNumber=66&amp;Timestamp=451578499.408528"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1280&amp;EndingColumnNumber=6&amp;EndingLineNumber=66&amp;StartingColumnNumber=5&amp;StartingLineNumber=66&amp;Timestamp=491664326.338492"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=1371&amp;EndingColumnNumber=31&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=451578897.352138"
+         documentLocation = "#CharacterRangeLen=30&amp;CharacterRangeLoc=1375&amp;EndingColumnNumber=31&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=491664326.338606"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6218&amp;EndingColumnNumber=91&amp;EndingLineNumber=176&amp;StartingColumnNumber=3&amp;StartingLineNumber=176&amp;Timestamp=453767546.118463"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=6246&amp;EndingColumnNumber=91&amp;EndingLineNumber=176&amp;StartingColumnNumber=3&amp;StartingLineNumber=176&amp;Timestamp=491664373.969792"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=7266&amp;EndingColumnNumber=14&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=453767925.034846"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=7306&amp;EndingColumnNumber=14&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491664373.969898"
          lockedSize = "{216, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7874&amp;EndingColumnNumber=17&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=453767925.035167"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7914&amp;EndingColumnNumber=17&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491664373.970009"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7281&amp;EndingColumnNumber=17&amp;EndingLineNumber=203&amp;StartingColumnNumber=1&amp;StartingLineNumber=203&amp;Timestamp=453767925.035483"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=7321&amp;EndingColumnNumber=17&amp;EndingLineNumber=203&amp;StartingColumnNumber=1&amp;StartingLineNumber=203&amp;Timestamp=491664373.970117"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=8060&amp;EndingColumnNumber=17&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=453767925.035839"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8093&amp;EndingColumnNumber=17&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491666839.55827"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1814&amp;EndingColumnNumber=16&amp;EndingLineNumber=90&amp;StartingColumnNumber=1&amp;StartingLineNumber=90&amp;Timestamp=453803034.154009"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=1818&amp;EndingColumnNumber=16&amp;EndingLineNumber=90&amp;StartingColumnNumber=1&amp;StartingLineNumber=90&amp;Timestamp=491664326.33931"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2015&amp;EndingColumnNumber=17&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=453767434.994122"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2019&amp;EndingColumnNumber=17&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491664326.339424"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/5a_flatMap_for_Array.playground/Contents.swift
+++ b/Playgrounds/5a_flatMap_for_Array.playground/Contents.swift
@@ -23,7 +23,11 @@ We can not simply apply the function **A -> Array<B>** to every element of **Arr
 The return type needs to be **Array<B>**. If we use the **map** function, we'd need to somehow flatten the **Array** before returning the result,
 alternatively, we could use a mutable **Array** and update it within a loop, or we could use the **reduce** function, as follows.
 */
-infix operator >>= {associativity left}
+precedencegroup BindPrecedence {
+	associativity: left
+	higherThan: AssignmentPrecedence
+}
+infix operator >>= : BindPrecedence
 func >>= <A,B>(x: [A], f: (A) -> [B]) -> [B] {
     return x.reduce([]) { result, item in result + f(item) }
 }

--- a/Playgrounds/5a_flatMap_for_Array.playground/timeline.xctimeline
+++ b/Playgrounds/5a_flatMap_for_Array.playground/timeline.xctimeline
@@ -3,138 +3,138 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=10367&amp;EndingColumnNumber=45&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491665920.651533"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=10454&amp;EndingColumnNumber=45&amp;EndingLineNumber=265&amp;StartingColumnNumber=1&amp;StartingLineNumber=265&amp;Timestamp=493545687.627737"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=11017&amp;EndingColumnNumber=44&amp;EndingLineNumber=274&amp;StartingColumnNumber=1&amp;StartingLineNumber=274&amp;Timestamp=491665920.651708"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=11104&amp;EndingColumnNumber=44&amp;EndingLineNumber=279&amp;StartingColumnNumber=1&amp;StartingLineNumber=279&amp;Timestamp=493545687.628016"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=3744&amp;EndingColumnNumber=14&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=3831&amp;EndingColumnNumber=14&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=493545687.628207"
          lockedSize = "{1011, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=3840&amp;EndingColumnNumber=17&amp;EndingLineNumber=105&amp;StartingColumnNumber=1&amp;StartingLineNumber=105&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=3927&amp;EndingColumnNumber=17&amp;EndingLineNumber=110&amp;StartingColumnNumber=1&amp;StartingLineNumber=110&amp;Timestamp=493545687.628425"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3944&amp;EndingColumnNumber=15&amp;EndingLineNumber=108&amp;StartingColumnNumber=1&amp;StartingLineNumber=108&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4031&amp;EndingColumnNumber=15&amp;EndingLineNumber=113&amp;StartingColumnNumber=1&amp;StartingLineNumber=113&amp;Timestamp=493545687.628666"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4118&amp;EndingColumnNumber=15&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4205&amp;EndingColumnNumber=15&amp;EndingLineNumber=121&amp;StartingColumnNumber=1&amp;StartingLineNumber=121&amp;Timestamp=493545687.62889"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4270&amp;EndingColumnNumber=15&amp;EndingLineNumber=127&amp;StartingColumnNumber=1&amp;StartingLineNumber=127&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4357&amp;EndingColumnNumber=15&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=493545687.629103"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=4534&amp;EndingColumnNumber=22&amp;EndingLineNumber=141&amp;StartingColumnNumber=1&amp;StartingLineNumber=141&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=4621&amp;EndingColumnNumber=22&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=493545687.629307"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4448&amp;EndingColumnNumber=19&amp;EndingLineNumber=135&amp;StartingColumnNumber=1&amp;StartingLineNumber=135&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4535&amp;EndingColumnNumber=19&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=493545687.629513"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4842&amp;EndingColumnNumber=44&amp;EndingLineNumber=149&amp;StartingColumnNumber=1&amp;StartingLineNumber=149&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4929&amp;EndingColumnNumber=44&amp;EndingLineNumber=154&amp;StartingColumnNumber=1&amp;StartingLineNumber=154&amp;Timestamp=493545687.629712"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=4624&amp;EndingColumnNumber=43&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=4711&amp;EndingColumnNumber=43&amp;EndingLineNumber=149&amp;StartingColumnNumber=1&amp;StartingLineNumber=149&amp;Timestamp=493545687.629912"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=44&amp;CharacterRangeLoc=5206&amp;EndingColumnNumber=45&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=44&amp;CharacterRangeLoc=5293&amp;EndingColumnNumber=45&amp;EndingLineNumber=163&amp;StartingColumnNumber=1&amp;StartingLineNumber=163&amp;Timestamp=493545687.630116"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5526&amp;EndingColumnNumber=44&amp;EndingLineNumber=161&amp;StartingColumnNumber=1&amp;StartingLineNumber=161&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5613&amp;EndingColumnNumber=44&amp;EndingLineNumber=166&amp;StartingColumnNumber=1&amp;StartingLineNumber=166&amp;Timestamp=493545687.630327"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=3839&amp;EndingColumnNumber=17&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=3926&amp;EndingColumnNumber=17&amp;EndingLineNumber=109&amp;StartingColumnNumber=1&amp;StartingLineNumber=109&amp;Timestamp=493545687.630544"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3943&amp;EndingColumnNumber=15&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4030&amp;EndingColumnNumber=15&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=493545687.630745"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4117&amp;EndingColumnNumber=15&amp;EndingLineNumber=115&amp;StartingColumnNumber=1&amp;StartingLineNumber=115&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4204&amp;EndingColumnNumber=15&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=493545687.630941"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=4269&amp;EndingColumnNumber=16&amp;EndingLineNumber=134&amp;StartingColumnNumber=5&amp;StartingLineNumber=134&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=4356&amp;EndingColumnNumber=16&amp;EndingLineNumber=139&amp;StartingColumnNumber=5&amp;StartingLineNumber=139&amp;Timestamp=493545687.631135"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4447&amp;EndingColumnNumber=19&amp;EndingLineNumber=130&amp;StartingColumnNumber=1&amp;StartingLineNumber=130&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=4534&amp;EndingColumnNumber=19&amp;EndingLineNumber=135&amp;StartingColumnNumber=1&amp;StartingLineNumber=135&amp;Timestamp=493545687.631376"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=4533&amp;EndingColumnNumber=22&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=4620&amp;EndingColumnNumber=22&amp;EndingLineNumber=138&amp;StartingColumnNumber=1&amp;StartingLineNumber=138&amp;Timestamp=493545687.631559"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=4623&amp;EndingColumnNumber=43&amp;EndingLineNumber=136&amp;StartingColumnNumber=1&amp;StartingLineNumber=136&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=4710&amp;EndingColumnNumber=43&amp;EndingLineNumber=141&amp;StartingColumnNumber=1&amp;StartingLineNumber=141&amp;Timestamp=493545687.631733"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=4841&amp;EndingColumnNumber=16&amp;EndingLineNumber=121&amp;StartingColumnNumber=5&amp;StartingLineNumber=121&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=4928&amp;EndingColumnNumber=16&amp;EndingLineNumber=126&amp;StartingColumnNumber=5&amp;StartingLineNumber=126&amp;Timestamp=493545687.631931"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=44&amp;CharacterRangeLoc=5075&amp;EndingColumnNumber=45&amp;EndingLineNumber=150&amp;StartingColumnNumber=1&amp;StartingLineNumber=150&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=44&amp;CharacterRangeLoc=5162&amp;EndingColumnNumber=45&amp;EndingLineNumber=155&amp;StartingColumnNumber=1&amp;StartingLineNumber=155&amp;Timestamp=493545687.632136"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5183&amp;EndingColumnNumber=44&amp;EndingLineNumber=153&amp;StartingColumnNumber=1&amp;StartingLineNumber=153&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5270&amp;EndingColumnNumber=44&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=493545687.632344"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5283&amp;EndingColumnNumber=44&amp;EndingLineNumber=156&amp;StartingColumnNumber=1&amp;StartingLineNumber=156&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5370&amp;EndingColumnNumber=44&amp;EndingLineNumber=161&amp;StartingColumnNumber=1&amp;StartingLineNumber=161&amp;Timestamp=493545687.63256"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5176&amp;EndingColumnNumber=44&amp;EndingLineNumber=153&amp;StartingColumnNumber=1&amp;StartingLineNumber=153&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5263&amp;EndingColumnNumber=44&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=493545687.632774"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1822&amp;EndingColumnNumber=10&amp;EndingLineNumber=65&amp;StartingColumnNumber=5&amp;StartingLineNumber=65&amp;Timestamp=452179596.060317"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1909&amp;EndingColumnNumber=10&amp;EndingLineNumber=70&amp;StartingColumnNumber=5&amp;StartingLineNumber=70&amp;Timestamp=493545687.632983"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=1805&amp;EndingColumnNumber=19&amp;EndingLineNumber=34&amp;StartingColumnNumber=1&amp;StartingLineNumber=34&amp;Timestamp=452179596.060317"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=1892&amp;EndingColumnNumber=19&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=493545687.633203"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -144,57 +144,57 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4327&amp;EndingColumnNumber=44&amp;EndingLineNumber=135&amp;StartingColumnNumber=1&amp;StartingLineNumber=135&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4414&amp;EndingColumnNumber=44&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=493545687.633627"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4220&amp;EndingColumnNumber=44&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4307&amp;EndingColumnNumber=44&amp;EndingLineNumber=137&amp;StartingColumnNumber=1&amp;StartingLineNumber=137&amp;Timestamp=493545687.633831"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4121&amp;EndingColumnNumber=44&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4208&amp;EndingColumnNumber=44&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=493545687.634027"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3891&amp;EndingColumnNumber=44&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3978&amp;EndingColumnNumber=44&amp;EndingLineNumber=127&amp;StartingColumnNumber=1&amp;StartingLineNumber=127&amp;Timestamp=493545687.63421"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=3673&amp;EndingColumnNumber=43&amp;EndingLineNumber=115&amp;StartingColumnNumber=1&amp;StartingLineNumber=115&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=3760&amp;EndingColumnNumber=43&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=493545687.634393"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3583&amp;EndingColumnNumber=22&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3670&amp;EndingColumnNumber=22&amp;EndingLineNumber=117&amp;StartingColumnNumber=1&amp;StartingLineNumber=117&amp;Timestamp=493545687.634528"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=3497&amp;EndingColumnNumber=19&amp;EndingLineNumber=109&amp;StartingColumnNumber=1&amp;StartingLineNumber=109&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=3584&amp;EndingColumnNumber=19&amp;EndingLineNumber=114&amp;StartingColumnNumber=1&amp;StartingLineNumber=114&amp;Timestamp=493545687.634636"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3319&amp;EndingColumnNumber=15&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3406&amp;EndingColumnNumber=15&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=493545687.634745"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3165&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3252&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=493545687.63485"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2987&amp;EndingColumnNumber=15&amp;EndingLineNumber=86&amp;StartingColumnNumber=1&amp;StartingLineNumber=86&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3074&amp;EndingColumnNumber=15&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=493545687.634955"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=2788&amp;EndingColumnNumber=16&amp;EndingLineNumber=103&amp;StartingColumnNumber=5&amp;StartingLineNumber=103&amp;Timestamp=452179764.461211"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=2875&amp;EndingColumnNumber=16&amp;EndingLineNumber=108&amp;StartingColumnNumber=5&amp;StartingLineNumber=108&amp;Timestamp=493545687.635065"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -204,72 +204,72 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3277&amp;EndingColumnNumber=44&amp;EndingLineNumber=117&amp;StartingColumnNumber=1&amp;StartingLineNumber=117&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3364&amp;EndingColumnNumber=44&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=493545687.635273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3170&amp;EndingColumnNumber=44&amp;EndingLineNumber=114&amp;StartingColumnNumber=1&amp;StartingLineNumber=114&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3257&amp;EndingColumnNumber=44&amp;EndingLineNumber=119&amp;StartingColumnNumber=1&amp;StartingLineNumber=119&amp;Timestamp=493545687.635376"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=3071&amp;EndingColumnNumber=43&amp;EndingLineNumber=111&amp;StartingColumnNumber=1&amp;StartingLineNumber=111&amp;Timestamp=452180423.846736"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=3158&amp;EndingColumnNumber=43&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=493545687.635479"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=2841&amp;EndingColumnNumber=44&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=2928&amp;EndingColumnNumber=44&amp;EndingLineNumber=109&amp;StartingColumnNumber=1&amp;StartingLineNumber=109&amp;Timestamp=493545687.635583"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=2623&amp;EndingColumnNumber=43&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=2710&amp;EndingColumnNumber=43&amp;EndingLineNumber=102&amp;StartingColumnNumber=1&amp;StartingLineNumber=102&amp;Timestamp=493545687.635687"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=2533&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=2620&amp;EndingColumnNumber=22&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=493545687.63579"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2447&amp;EndingColumnNumber=19&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2534&amp;EndingColumnNumber=19&amp;EndingLineNumber=96&amp;StartingColumnNumber=1&amp;StartingLineNumber=96&amp;Timestamp=493545687.635893"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2269&amp;EndingColumnNumber=15&amp;EndingLineNumber=83&amp;StartingColumnNumber=1&amp;StartingLineNumber=83&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2356&amp;EndingColumnNumber=15&amp;EndingLineNumber=88&amp;StartingColumnNumber=1&amp;StartingLineNumber=88&amp;Timestamp=493545687.635996"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2115&amp;EndingColumnNumber=15&amp;EndingLineNumber=76&amp;StartingColumnNumber=1&amp;StartingLineNumber=76&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2202&amp;EndingColumnNumber=15&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=493545687.636099"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1937&amp;EndingColumnNumber=15&amp;EndingLineNumber=68&amp;StartingColumnNumber=1&amp;StartingLineNumber=68&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2024&amp;EndingColumnNumber=15&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=493545687.636202"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=1833&amp;EndingColumnNumber=17&amp;EndingLineNumber=65&amp;StartingColumnNumber=1&amp;StartingLineNumber=65&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=1920&amp;EndingColumnNumber=17&amp;EndingLineNumber=70&amp;StartingColumnNumber=1&amp;StartingLineNumber=70&amp;Timestamp=493545687.636305"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1738&amp;EndingColumnNumber=14&amp;EndingLineNumber=62&amp;StartingColumnNumber=1&amp;StartingLineNumber=62&amp;Timestamp=452179824.017263"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1825&amp;EndingColumnNumber=14&amp;EndingLineNumber=67&amp;StartingColumnNumber=1&amp;StartingLineNumber=67&amp;Timestamp=493545687.636409"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3276&amp;EndingColumnNumber=44&amp;EndingLineNumber=117&amp;StartingColumnNumber=1&amp;StartingLineNumber=117&amp;Timestamp=452180429.402652"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3363&amp;EndingColumnNumber=44&amp;EndingLineNumber=122&amp;StartingColumnNumber=1&amp;StartingLineNumber=122&amp;Timestamp=493545687.636524"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3169&amp;EndingColumnNumber=44&amp;EndingLineNumber=114&amp;StartingColumnNumber=1&amp;StartingLineNumber=114&amp;Timestamp=452180429.402652"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=3256&amp;EndingColumnNumber=44&amp;EndingLineNumber=119&amp;StartingColumnNumber=1&amp;StartingLineNumber=119&amp;Timestamp=493545687.63664"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/5a_flatMap_for_Array.playground/timeline.xctimeline
+++ b/Playgrounds/5a_flatMap_for_Array.playground/timeline.xctimeline
@@ -3,12 +3,12 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=10351&amp;EndingColumnNumber=45&amp;EndingLineNumber=258&amp;StartingColumnNumber=1&amp;StartingLineNumber=258&amp;Timestamp=452180339.895082"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=10367&amp;EndingColumnNumber=45&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491665920.651533"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=11001&amp;EndingColumnNumber=44&amp;EndingLineNumber=272&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=452180339.895082"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=11017&amp;EndingColumnNumber=44&amp;EndingLineNumber=274&amp;StartingColumnNumber=1&amp;StartingLineNumber=274&amp;Timestamp=491665920.651708"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
@@ -108,7 +108,7 @@ But first, Swift doesn't have built-in functions for **sum** and **average**, so
 They'll be very useful.
 */
 func sum(_ x:[Int]) -> Int {
-    return x.reduce(0, combine: +)
+    return x.reduce(0, +)
 }
 
 func average(_ x:[Int]) -> Float {
@@ -251,7 +251,7 @@ If the **Array** isn't empty the normal **reduce** function will be called using
 func reduce1<A>(_ f:(A,A) -> A) -> ([A]) -> A? {
 	return { xs in
 		return xs.first.map { x in
-			xs[xs.indices.suffix(from: 1)].reduce(x, combine: f)
+			xs[xs.indices.suffix(from: 1)].reduce(x, f)
 		}
 	}
 }

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
@@ -5,24 +5,24 @@ The previous Playground introduced **flatMap** for **Array** using calculations 
 We're not finished with the **Squirrels**, **Nuts** and **Caches** just yet, so here they are:
 */
 enum Nut: CustomStringConvertible {
-    case Acorn, Hazel, Chestnut, Cashew
+    case acorn, hazel, chestnut, cashew
     
     var description: String { // boring boilerplate
         switch self {
-        case .Acorn :    return "Acorn"
-        case .Hazel :    return "Hazel"
-        case .Chestnut : return "Chestnut"
-        case .Cashew :   return "Cashew"
+        case .acorn :    return "Acorn"
+        case .hazel :    return "Hazel"
+        case .chestnut : return "Chestnut"
+        case .cashew :   return "Cashew"
         }
     }
 }
 //: Some calorie info will be very useful
-func calories(nut:Nut) -> Int {
+func calories(_ nut:Nut) -> Int {
     switch nut {
-    case .Acorn :    return 15
-    case .Hazel :    return 10
-    case .Chestnut : return 25
-    case .Cashew :   return 10
+    case .acorn :    return 15
+    case .hazel :    return 10
+    case .chestnut : return 25
+    case .cashew :   return 10
     }
 }
 /*:
@@ -43,44 +43,46 @@ struct Squirrel {
         return self.caches.flatMap { cache in cache.nuts }
     }
     
-    func nutsOfType(nut:Nut) -> [Nut] {
+    func nutsOfType(_ nut:Nut) -> [Nut] {
         return self.nuts.filter { n in n == nut }
     }
 }
 
-func nuts(squirrel:Squirrel) -> [Nut] {
+func nuts(_ squirrel:Squirrel) -> [Nut] {
     return squirrel.caches.flatMap { cache in cache.nuts }
 }
 
-func nutsOfType(nut:Nut)(squirrel:Squirrel) -> [Nut] {
-    return nuts(squirrel).filter { $0 == nut }
+func nutsOfType(_ nut:Nut) -> (Squirrel) -> [Nut] {
+	return { squirrel in
+		return nuts(squirrel).filter { $0 == nut }
+	}
 }
 /*:
 ## Create a gang of **Squirrels**
 */
 let fred = Squirrel(name: "Fred", caches: [
     Cache(location: (104, -20),
-              nuts: [.Acorn, .Acorn, .Chestnut, .Cashew]),
+              nuts: [.acorn, .acorn, .chestnut, .cashew]),
     Cache(location: (87, 45),
-              nuts: [.Hazel, .Chestnut])])
+              nuts: [.hazel, .chestnut])])
 
 let bob = Squirrel(name: "Bob", caches: [
     Cache(location: (-12, 15),
-              nuts: Array(count: 12, repeatedValue: .Cashew))])
+              nuts: Array(repeating: .cashew, count: 12))])
 
 let jane = Squirrel(name: "Jane", caches: [
     Cache(location: (-36, -96),
-              nuts: Array(count: 10, repeatedValue: .Acorn)),
+              nuts: Array(repeating: .acorn, count: 10)),
     Cache(location: (212, 4),
-              nuts: [.Chestnut, .Chestnut, .Hazel])])
+              nuts: [.chestnut, .chestnut, .hazel])])
 
 let bertha = Squirrel(name: "Bertha", caches: [
     Cache(location: (24, -164),
-              nuts: Array(count: 8, repeatedValue: .Acorn)),
+              nuts: Array(repeating: .acorn, count: 8)),
     Cache(location: (-129, 10),
-              nuts: [.Acorn, .Hazel, .Hazel, .Hazel, .Chestnut]),
+              nuts: [.acorn, .hazel, .hazel, .hazel, .chestnut]),
     Cache(location: (27, -16),
-              nuts: [.Hazel, .Hazel, .Chestnut])])
+              nuts: [.hazel, .hazel, .chestnut])])
 
 
 let squirrels = [fred, bob, jane, bertha]
@@ -91,10 +93,10 @@ Last time we managed to create a few functions that could be used with **flatMap
 The use of top-level curried functions enabled us to write succinct and elegant code.
 Here are a couple of examples from last time:
 */
-let allChestnuts = squirrels.flatMap(nutsOfType(.Chestnut))
+let allChestnuts = squirrels.flatMap(nutsOfType(.chestnut))
 print(allChestnuts)
 
-let acornCount = squirrels.flatMap(nutsOfType(.Acorn)).count
+let acornCount = squirrels.flatMap(nutsOfType(.acorn)).count
 print("Number of acorns: \(acornCount)")
 
 /*:
@@ -105,11 +107,11 @@ The pipe forward operator **|>** will also be introduced, along with the **minBy
 But first, Swift doesn't have built-in functions for **sum** and **average**, so let's create them.
 They'll be very useful.
 */
-func sum(x:[Int]) -> Int {
+func sum(_ x:[Int]) -> Int {
     return x.reduce(0, combine: +)
 }
 
-func average(x:[Int]) -> Float {
+func average(_ x:[Int]) -> Float {
     return Float(sum(x)) / Float(x.count)
 }
 /*:
@@ -130,15 +132,15 @@ All of the above questions will require the use of **flatMap**.
 Let's extend the **Cache** type to conform to the *CustomStringConvertible* protocol.
 */
 extension Cache: CustomStringConvertible {
-    func countNutsOfType(nut:Nut) -> Int {
+    func countNutsOfType(_ nut:Nut) -> Int {
         return self.nuts.filter { $0 == nut }.count
     }
     
     var description: String {
-        let acorns = countNutsOfType(.Acorn)
-        let hazels = countNutsOfType(.Hazel)
-        let chestnuts = countNutsOfType(.Chestnut)
-        let cashews = countNutsOfType(.Cashew)
+        let acorns = countNutsOfType(.acorn)
+        let hazels = countNutsOfType(.hazel)
+        let chestnuts = countNutsOfType(.chestnut)
+        let cashews = countNutsOfType(.cashew)
         
         return "location: \(location) { acorns: \(acorns), hazels: \(hazels), chestnuts: \(chestnuts), cashews: \(cashews) }"
     }
@@ -148,20 +150,22 @@ A top-level curried function **nutsOfType** that takes a **Cache** as an argumen
 This is an overloaded function (meaning that there is already a function with this name,
 however, the other version takes a **Squirrel** as an argument, not a **Cache**).
 */
-func nutsOfType(nut:Nut)(cache:Cache) -> [Nut] {
-    return cache.nuts.filter { $0 == nut }
+func nutsOfType(_ nut:Nut) -> (Cache) -> [Nut] {
+	return { cache in
+		return cache.nuts.filter { $0 == nut }
+	}
 }
 /*:
 A top-level function to calculate the distance to a **Cache**
 */
 import Foundation // needed for sqrt function
-func distance(cache:Cache) -> Float {
+func distance(_ cache:Cache) -> Float {
     return sqrt(cache.location.x * cache.location.x + cache.location.y * cache.location.y)
 }
 /*:
 It should now be an easy task to take an **Array** of **Squirrels** and calculate the distance to the closest **Cache**.
 */
-let closestCacheDistance = squirrels.flatMap { $0.caches }.map(distance).minElement()!
+let closestCacheDistance = squirrels.flatMap { $0.caches }.map(distance).min()!
 print("Distance to closest Cache: \(closestCacheDistance)m")
 
 /*:
@@ -179,7 +183,7 @@ The left-hand side of the operator takes a value of type **A**, the right-hand s
 The *pipe forward operator* simply applies the function to the value:
 */
 infix operator |> {associativity left precedence 95}
-func |> <A,B>(x:A, f:A -> B) -> B {
+func |> <A,B>(x:A, f:(A) -> B) -> B {
     return f(x)
 }
 /*:
@@ -190,14 +194,14 @@ The **minElement** function can now be applied at the end of the expresssion.
 let closestCacheDistance2 = squirrels
                            .flatMap { $0.caches }
                            .map(distance)
-                           |> { $0.minElement()! }
+                           |> { $0.min()! }
 
 print("Distance to closest Cache: \(closestCacheDistance2)m")
 
 let mostNuts = squirrels
               .flatMap { $0.caches }
               .map {$0.nuts.count}
-              |> { $0.maxElement()! }
+              |> { $0.max()! }
 
 print("Number of nuts in biggest cache: \(mostNuts)")
 
@@ -218,13 +222,13 @@ print("Total calories in caches: \(allCals)")
 
 let hazelWithin50m = squirrels
                     .flatMap { $0.caches }
-                    .filter { distance($0) < 50 && $0.nuts.contains(.Hazel) }
+                    .filter { distance($0) < 50 && $0.nuts.contains(.hazel) }
 
 print("Hazel nuts within 50m: \n\(hazelWithin50m)")
 
 let noChestnuts = squirrels
                  .flatMap { $0.caches }
-                 .filter { ($0 |> nutsOfType(.Chestnut)).count == 0 }
+                 .filter { ($0 |> nutsOfType(.chestnut)).count == 0 }
 
 print("Caches containing no Chestnuts: \n\(noChestnuts)")
 
@@ -236,18 +240,20 @@ It is similar to the normal **reduce** function, accept that an initial value is
 The return type is also dictated by the contents of the **Array** that is being reduced.
 The Haskell version of this function is unsafe to use on an empty list, this is not the case
 for the Swift version below, as the return type is an **Optional**. 
-If an empty **Array** is passed to the function the return value will be **.None**.
+If an empty **Array** is passed to the function the return value will be **.none**.
 
 * * *
 
 Use **first** to take the first element of the supplied **Array**. The return value of **first** is an **Optional**.
-Therefore use **map** on the return value of **first** - if the **Array** is empty the whole expression will return **.None**.
+Therefore use **map** on the return value of **first** - if the **Array** is empty the whole expression will return **.none**.
 If the **Array** isn't empty the normal **reduce** function will be called using the first element as the initial value.
 */
-func reduce1<A>(f:(A,A) -> A)(_ xs:[A]) -> A? {
-    return xs.first.map { x in
-        xs[1..<xs.endIndex].reduce(x, combine: f)
-    }
+func reduce1<A>(_ f:(A,A) -> A) -> ([A]) -> A? {
+	return { xs in
+		return xs.first.map { x in
+			xs[xs.indices.suffix(from: 1)].reduce(x, combine: f)
+		}
+	}
 }
 
 [1,2,3,4] |> reduce1(*) // yay, it works
@@ -258,12 +264,16 @@ func reduce1<A>(f:(A,A) -> A)(_ xs:[A]) -> A? {
 Using **reduce1** it is now possible to implement **minBy** & **maxBy**.
 The idea is to be able to select the min or max element from an **Array** based upon any property of the elements.
 */
-func minBy<A,B:Comparable>(f:A -> B)(xs:[A]) -> A? {
-    return xs |> reduce1 { x,y in f(x) < f(y) ? x : y }
+func minBy<A,B:Comparable>(_ f:(A) -> B) -> ([A]) -> A? {
+	return { xs in
+		return xs |> reduce1 { x,y in f(x) < f(y) ? x : y }
+	}
 }
 
-func maxBy<A,B:Comparable>(f:A -> B)(xs:[A]) -> A? {
-    return xs |> reduce1 { x,y in f(x) > f(y) ? x : y }
+func maxBy<A,B:Comparable>(_ f:(A) -> B) -> ([A]) -> A? {
+	return { xs in
+		return xs |> reduce1 { x,y in f(x) > f(y) ? x : y }
+	}
 }
 /*:
 ### **minBy** & **maxBy** in action
@@ -288,13 +298,13 @@ print("Cache with most calories: \n\(mostCals)")
 
 let abundantHazels = squirrels
                     .flatMap { $0.caches }
-                    |> maxBy { $0 |> nutsOfType(.Hazel) |> { $0.count } }
+                    |> maxBy { $0 |> nutsOfType(.hazel) |> { $0.count } }
 
 print("Cache containing most Hazels: \n\(abundantHazels)")
 
 let closestAcorns = squirrels
                    .flatMap { $0.caches }
-                   .filter { ($0 |> nutsOfType(.Acorn)).count > 0 }
+                   .filter { ($0 |> nutsOfType(.acorn)).count > 0 }
                    |> minBy(distance)
 
 print("Nearest cache containing Acorns: \n\(closestAcorns)")
@@ -319,13 +329,13 @@ All these questions and more can be answered by combining the functions we've cr
 First, let's extend **Squirrel** to be **CustomStringConvertible**.
 The **curry** function below is used to curry the **joinWithSeparator** function when constructing a *description* **String**.
 */
-func curry<A,B,C>(f:(A,B) -> C) -> A -> B -> C {
+func curry<A,B,C>(_ f:(A,B) -> C) -> (A) -> (B) -> C {
     return { a in { b in f(a,b) } }
 }
 
 extension Squirrel: CustomStringConvertible {
     var description: String {
-		let cachesString = caches.map { $0.description } |> curry({ $1.joinWithSeparator($0) })("\n")
+		let cachesString = caches.map { $0.description } |> curry({ $1.joined(separator: $0) })("\n")
         
         return "\(name)\n\(cachesString)"
     }
@@ -341,7 +351,7 @@ let lazySquirrel = squirrels |> minBy { $0.nuts |> { $0.count } }
 
 print("Laziest squirrel: \n\(lazySquirrel)")
 
-let acornHunter = squirrels |> maxBy { $0 |> nutsOfType(.Acorn) |> { $0.count } }
+let acornHunter = squirrels |> maxBy { $0 |> nutsOfType(.acorn) |> { $0.count } }
 
 print("Squirrel with most acorns: \n\(acornHunter)")
 
@@ -349,7 +359,7 @@ let mostCaches = squirrels |> maxBy { $0.caches.count }
 
 print("Squirrel with most Caches: \n\(mostCaches)")
 
-let closest = squirrels |> minBy { $0.caches.map(distance) |> { $0.minElement()! } }
+let closest = squirrels |> minBy { $0.caches.map(distance) |> { $0.min()! } }
 
 print("Squirrel with closest Cache: \n\(closest)")
 /*:

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/Contents.swift
@@ -182,7 +182,11 @@ With the introduction of a new *infix operator* the flow of the code will be a l
 The left-hand side of the operator takes a value of type **A**, the right-hand side takes a function of type **A -> B**.
 The *pipe forward operator* simply applies the function to the value:
 */
-infix operator |> {associativity left precedence 95}
+precedencegroup PipePrecedence {
+	associativity: left
+	higherThan: AssignmentPrecedence
+}
+infix operator |> : PipePrecedence
 func |> <A,B>(x:A, f:(A) -> B) -> B {
     return f(x)
 }
@@ -248,7 +252,7 @@ Use **first** to take the first element of the supplied **Array**. The return va
 Therefore use **map** on the return value of **first** - if the **Array** is empty the whole expression will return **.none**.
 If the **Array** isn't empty the normal **reduce** function will be called using the first element as the initial value.
 */
-func reduce1<A>(_ f:(A,A) -> A) -> ([A]) -> A? {
+func reduce1<A>(_ f:@escaping (A,A) -> A) -> ([A]) -> A? {
 	return { xs in
 		return xs.first.map { x in
 			xs[xs.indices.suffix(from: 1)].reduce(x, f)
@@ -264,13 +268,13 @@ func reduce1<A>(_ f:(A,A) -> A) -> ([A]) -> A? {
 Using **reduce1** it is now possible to implement **minBy** & **maxBy**.
 The idea is to be able to select the min or max element from an **Array** based upon any property of the elements.
 */
-func minBy<A,B:Comparable>(_ f:(A) -> B) -> ([A]) -> A? {
+func minBy<A,B:Comparable>(_ f:@escaping (A) -> B) -> ([A]) -> A? {
 	return { xs in
 		return xs |> reduce1 { x,y in f(x) < f(y) ? x : y }
 	}
 }
 
-func maxBy<A,B:Comparable>(_ f:(A) -> B) -> ([A]) -> A? {
+func maxBy<A,B:Comparable>(_ f:@escaping (A) -> B) -> ([A]) -> A? {
 	return { xs in
 		return xs |> reduce1 { x,y in f(x) > f(y) ? x : y }
 	}
@@ -329,7 +333,7 @@ All these questions and more can be answered by combining the functions we've cr
 First, let's extend **Squirrel** to be **CustomStringConvertible**.
 The **curry** function below is used to curry the **joinWithSeparator** function when constructing a *description* **String**.
 */
-func curry<A,B,C>(_ f:(A,B) -> C) -> (A) -> (B) -> C {
+func curry<A,B,C>(_ f:@escaping (A,B) -> C) -> (A) -> (B) -> C {
     return { a in { b in f(a,b) } }
 }
 

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=491666546.921066"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -18,1046 +18,1046 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=2&amp;EndingLineNumber=92&amp;StartingColumnNumber=2&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=2&amp;EndingLineNumber=94&amp;StartingColumnNumber=2&amp;StartingLineNumber=94&amp;Timestamp=491666047.996189"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=19&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=19&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.996324"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=19&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=19&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=491666047.996455"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.996583"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.99671"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=83&amp;EndingLineNumber=92&amp;StartingColumnNumber=73&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=83&amp;EndingLineNumber=94&amp;StartingColumnNumber=73&amp;StartingLineNumber=94&amp;Timestamp=491666047.996837"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=57&amp;EndingLineNumber=92&amp;StartingColumnNumber=47&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=57&amp;EndingLineNumber=94&amp;StartingColumnNumber=47&amp;StartingLineNumber=94&amp;Timestamp=491666047.996974"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.997109"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=17&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=17&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491666047.997246"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=42&amp;EndingLineNumber=92&amp;StartingColumnNumber=16&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=42&amp;EndingLineNumber=94&amp;StartingColumnNumber=16&amp;StartingLineNumber=94&amp;Timestamp=491666047.997381"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=17&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=17&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491666047.997516"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2361&amp;EndingColumnNumber=17&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2377&amp;EndingColumnNumber=17&amp;EndingLineNumber=86&amp;StartingColumnNumber=1&amp;StartingLineNumber=86&amp;Timestamp=491666047.997651"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491666047.997785"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.997918"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=304&amp;StartingColumnNumber=12&amp;StartingLineNumber=304&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491666546.92398"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=304&amp;StartingColumnNumber=12&amp;StartingLineNumber=304&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491666546.924163"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=12&amp;EndingLineNumber=290&amp;StartingColumnNumber=1&amp;StartingLineNumber=290&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.924354"
          lockedSize = "{720, 71}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=12&amp;EndingLineNumber=319&amp;StartingColumnNumber=1&amp;StartingLineNumber=319&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=329&amp;StartingColumnNumber=1&amp;StartingLineNumber=329&amp;Timestamp=491666546.924554"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=305&amp;StartingColumnNumber=12&amp;StartingLineNumber=305&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=315&amp;StartingColumnNumber=12&amp;StartingLineNumber=315&amp;Timestamp=491666546.924747"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=13&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=13&amp;EndingLineNumber=333&amp;StartingColumnNumber=1&amp;StartingLineNumber=333&amp;Timestamp=491666546.924942"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=13&amp;EndingLineNumber=333&amp;StartingColumnNumber=1&amp;StartingLineNumber=333&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=13&amp;EndingLineNumber=343&amp;StartingColumnNumber=1&amp;StartingLineNumber=343&amp;Timestamp=491666546.925133"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=21&amp;EndingLineNumber=350&amp;StartingColumnNumber=1&amp;StartingLineNumber=350&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=360&amp;StartingColumnNumber=1&amp;StartingLineNumber=360&amp;Timestamp=491666546.925323"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=22&amp;EndingLineNumber=353&amp;StartingColumnNumber=1&amp;StartingLineNumber=353&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=22&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491666546.925523"
          lockedSize = "{489, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=21&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=21&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.925726"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=14&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=14&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666047.99942"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=11&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=11&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666539.873498"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=14&amp;EndingLineNumber=86&amp;StartingColumnNumber=1&amp;StartingLineNumber=86&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=14&amp;EndingLineNumber=88&amp;StartingColumnNumber=1&amp;StartingLineNumber=88&amp;Timestamp=491666047.999691"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=14&amp;EndingLineNumber=86&amp;StartingColumnNumber=1&amp;StartingLineNumber=86&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=14&amp;EndingLineNumber=88&amp;StartingColumnNumber=1&amp;StartingLineNumber=88&amp;Timestamp=491666047.999825"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491666047.999958"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000089"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=14&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=14&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000225"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=19&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=19&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000348"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=19&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=19&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000471"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=2&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=2&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000593"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=1&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=1&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.000713"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=2&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=2&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.000836"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=25&amp;EndingLineNumber=104&amp;StartingColumnNumber=5&amp;StartingLineNumber=104&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=25&amp;EndingLineNumber=106&amp;StartingColumnNumber=5&amp;StartingLineNumber=106&amp;Timestamp=491666048.000957"
          lockedSize = "{426, 66}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=13&amp;EndingLineNumber=138&amp;StartingColumnNumber=1&amp;StartingLineNumber=138&amp;Timestamp=452640938.793149"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=13&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491666048.001322"
          lockedSize = "{428, 73}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1415&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=23&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=1411&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.928401"
          lockedSize = "{421, 73}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=23&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.928593"
          lockedSize = "{765, 78}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=8&amp;EndingLineNumber=268&amp;StartingColumnNumber=5&amp;StartingLineNumber=268&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=8&amp;EndingLineNumber=278&amp;StartingColumnNumber=5&amp;StartingLineNumber=278&amp;Timestamp=491666546.928776"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=21&amp;EndingLineNumber=290&amp;StartingColumnNumber=1&amp;StartingLineNumber=290&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.928957"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=22&amp;EndingLineNumber=298&amp;StartingColumnNumber=1&amp;StartingLineNumber=298&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=22&amp;EndingLineNumber=308&amp;StartingColumnNumber=1&amp;StartingLineNumber=308&amp;Timestamp=491666546.929134"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=21&amp;EndingLineNumber=301&amp;StartingColumnNumber=1&amp;StartingLineNumber=301&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=311&amp;StartingColumnNumber=1&amp;StartingLineNumber=311&amp;Timestamp=491666546.929311"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=12&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=12&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.003486"
          lockedSize = "{438, 69}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=21&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=21&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.003714"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=39&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=39&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.003934"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=39&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=39&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.00415"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=44&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=44&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=491666048.004363"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=50&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=50&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.004576"
          lockedSize = "{258, 67}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.930602"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.930782"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=47&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.93097"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=51&amp;EndingLineNumber=163&amp;StartingColumnNumber=1&amp;StartingLineNumber=163&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=51&amp;EndingLineNumber=167&amp;StartingColumnNumber=1&amp;StartingLineNumber=167&amp;Timestamp=491666546.931163"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=50&amp;EndingLineNumber=115&amp;StartingColumnNumber=1&amp;StartingLineNumber=115&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=50&amp;EndingLineNumber=117&amp;StartingColumnNumber=1&amp;StartingLineNumber=117&amp;Timestamp=491666048.005447"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=17&amp;EndingLineNumber=113&amp;StartingColumnNumber=5&amp;StartingLineNumber=113&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=17&amp;EndingLineNumber=115&amp;StartingColumnNumber=5&amp;StartingLineNumber=115&amp;Timestamp=491666048.005575"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=39&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=39&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.005703"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=54&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=54&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.005829"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=44&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=44&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.005968"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=65&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=65&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.00625"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.00646"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.006668"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=48&amp;EndingLineNumber=113&amp;StartingColumnNumber=1&amp;StartingLineNumber=113&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=48&amp;EndingLineNumber=115&amp;StartingColumnNumber=1&amp;StartingLineNumber=115&amp;Timestamp=491666048.006882"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=61&amp;EndingLineNumber=332&amp;StartingColumnNumber=1&amp;StartingLineNumber=332&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=61&amp;EndingLineNumber=342&amp;StartingColumnNumber=1&amp;StartingLineNumber=342&amp;Timestamp=491666546.933009"
          lockedSize = "{520, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=20&amp;EndingLineNumber=139&amp;StartingColumnNumber=13&amp;StartingLineNumber=139&amp;Timestamp=452640938.793149"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=20&amp;EndingLineNumber=141&amp;StartingColumnNumber=13&amp;StartingLineNumber=141&amp;Timestamp=491666048.007304"
          lockedSize = "{415, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=18&amp;EndingLineNumber=117&amp;StartingColumnNumber=5&amp;StartingLineNumber=117&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=18&amp;EndingLineNumber=119&amp;StartingColumnNumber=5&amp;StartingLineNumber=119&amp;Timestamp=491666048.00743"
          lockedSize = "{423, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.933574"
          lockedSize = "{550, 94}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=47&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.933766"
          lockedSize = "{543, 83}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=268&amp;StartingColumnNumber=1&amp;StartingLineNumber=268&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=278&amp;Timestamp=491666546.933956"
          lockedSize = "{544, 89}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=18&amp;EndingLineNumber=137&amp;StartingColumnNumber=5&amp;StartingLineNumber=137&amp;Timestamp=452640938.793149"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=18&amp;EndingLineNumber=139&amp;StartingColumnNumber=5&amp;StartingLineNumber=139&amp;Timestamp=491666048.007927"
          lockedSize = "{420, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=50&amp;EndingLineNumber=115&amp;StartingColumnNumber=1&amp;StartingLineNumber=115&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=50&amp;EndingLineNumber=117&amp;StartingColumnNumber=1&amp;StartingLineNumber=117&amp;Timestamp=491666048.008047"
          lockedSize = "{421, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=22&amp;EndingLineNumber=115&amp;StartingColumnNumber=5&amp;StartingLineNumber=115&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=22&amp;EndingLineNumber=117&amp;StartingColumnNumber=5&amp;StartingLineNumber=117&amp;Timestamp=491666048.008165"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3111&amp;EndingColumnNumber=13&amp;EndingLineNumber=104&amp;StartingColumnNumber=5&amp;StartingLineNumber=104&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3127&amp;EndingColumnNumber=13&amp;EndingLineNumber=106&amp;StartingColumnNumber=5&amp;StartingLineNumber=106&amp;Timestamp=491666048.008281"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=65&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=65&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.008396"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=54&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=54&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666048.00851"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=58&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=58&amp;EndingLineNumber=199&amp;StartingColumnNumber=1&amp;StartingLineNumber=199&amp;Timestamp=491666546.935245"
          lockedSize = "{416, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=17&amp;EndingLineNumber=248&amp;StartingColumnNumber=5&amp;StartingLineNumber=246&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=17&amp;EndingLineNumber=254&amp;StartingColumnNumber=5&amp;StartingLineNumber=254&amp;Timestamp=491666546.935437"
          lockedSize = "{815, 67}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=271&amp;StartingColumnNumber=1&amp;StartingLineNumber=271&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=281&amp;StartingColumnNumber=1&amp;StartingLineNumber=281&amp;Timestamp=491666546.935619"
          lockedSize = "{548, 85}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=272&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.935799"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=21&amp;EndingLineNumber=272&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.935977"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=30&amp;EndingLineNumber=272&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=30&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.936152"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=3&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=3&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491666546.936327"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=12&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491666546.936503"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=272&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.936679"
          lockedSize = "{548, 75}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=65&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=65&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491666546.936861"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=54&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=54&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491666546.937045"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=55&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=55&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937221"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=56&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937397"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=56&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937572"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=56&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937747"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=3&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=3&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937931"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=12&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=12&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.938111"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.938291"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=53&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.938471"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=54&amp;EndingLineNumber=259&amp;StartingColumnNumber=1&amp;StartingLineNumber=259&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=54&amp;EndingLineNumber=265&amp;StartingColumnNumber=1&amp;StartingLineNumber=265&amp;Timestamp=491666546.938653"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=255&amp;StartingColumnNumber=1&amp;StartingLineNumber=255&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=261&amp;StartingColumnNumber=1&amp;StartingLineNumber=261&amp;Timestamp=491666546.938832"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=47&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=246&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491666546.939012"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=341&amp;CharacterRangeLoc=4434&amp;EndingColumnNumber=46&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=337&amp;CharacterRangeLoc=4450&amp;EndingColumnNumber=46&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.939191"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=37&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=37&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.011268"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=17&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=17&amp;EndingLineNumber=87&amp;StartingColumnNumber=1&amp;StartingLineNumber=87&amp;Timestamp=491666048.011373"
          lockedSize = "{730, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=14&amp;EndingLineNumber=87&amp;StartingColumnNumber=1&amp;StartingLineNumber=87&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=14&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=491666048.011482"
          lockedSize = "{725, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.011599"
          lockedSize = "{723, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=15&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=15&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.011715"
          lockedSize = "{724, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=2&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=2&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.012159"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=19&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=19&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.012442"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=22&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.012717"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2641&amp;EndingColumnNumber=19&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=2657&amp;EndingColumnNumber=19&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.012967"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=63&amp;EndingLineNumber=294&amp;StartingColumnNumber=1&amp;StartingLineNumber=294&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=63&amp;EndingLineNumber=304&amp;StartingColumnNumber=1&amp;StartingLineNumber=304&amp;Timestamp=491666546.940976"
          lockedSize = "{478, 60}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.941164"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=55&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491666546.94134"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=61&amp;EndingLineNumber=289&amp;StartingColumnNumber=1&amp;StartingLineNumber=289&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=61&amp;EndingLineNumber=299&amp;StartingColumnNumber=1&amp;StartingLineNumber=299&amp;Timestamp=491666546.941517"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4775&amp;EndingColumnNumber=60&amp;EndingLineNumber=290&amp;StartingColumnNumber=1&amp;StartingLineNumber=290&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=60&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.94169"
          lockedSize = "{815, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2068&amp;EndingColumnNumber=19&amp;EndingLineNumber=89&amp;StartingColumnNumber=1&amp;StartingLineNumber=89&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2084&amp;EndingColumnNumber=19&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491666048.013975"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=134&amp;CharacterRangeLoc=2505&amp;EndingColumnNumber=44&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=452623973.575798"
+         documentLocation = "#CharacterRangeLen=134&amp;CharacterRangeLoc=2521&amp;EndingColumnNumber=44&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491666048.014102"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3572&amp;EndingColumnNumber=46&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=246&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3588&amp;EndingColumnNumber=46&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491666546.942216"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3360&amp;EndingColumnNumber=64&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=64&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491666546.942394"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=1413&amp;EndingColumnNumber=17&amp;EndingLineNumber=65&amp;StartingColumnNumber=1&amp;StartingLineNumber=65&amp;Timestamp=452623958.269326"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=1429&amp;EndingColumnNumber=17&amp;EndingLineNumber=67&amp;StartingColumnNumber=1&amp;StartingLineNumber=67&amp;Timestamp=491666048.014474"
          lockedSize = "{745, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1516&amp;EndingColumnNumber=14&amp;EndingLineNumber=68&amp;StartingColumnNumber=1&amp;StartingLineNumber=68&amp;Timestamp=452623958.269326"
+         documentLocation = "#CharacterRangeLen=22&amp;CharacterRangeLoc=1532&amp;EndingColumnNumber=14&amp;EndingLineNumber=70&amp;StartingColumnNumber=1&amp;StartingLineNumber=70&amp;Timestamp=491666048.014592"
          lockedSize = "{723, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1702&amp;EndingColumnNumber=15&amp;EndingLineNumber=76&amp;StartingColumnNumber=1&amp;StartingLineNumber=76&amp;Timestamp=452623958.269326"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1718&amp;EndingColumnNumber=15&amp;EndingLineNumber=78&amp;StartingColumnNumber=1&amp;StartingLineNumber=78&amp;Timestamp=491666048.014713"
          lockedSize = "{717, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9329&amp;EndingColumnNumber=59&amp;EndingLineNumber=276&amp;StartingColumnNumber=1&amp;StartingLineNumber=276&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9402&amp;EndingColumnNumber=59&amp;EndingLineNumber=286&amp;StartingColumnNumber=1&amp;StartingLineNumber=286&amp;Timestamp=491666546.943096"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9272&amp;EndingColumnNumber=58&amp;EndingLineNumber=275&amp;StartingColumnNumber=1&amp;StartingLineNumber=275&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9345&amp;EndingColumnNumber=58&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=491666546.943273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=56&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.943449"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11643&amp;EndingColumnNumber=55&amp;EndingLineNumber=353&amp;StartingColumnNumber=1&amp;StartingLineNumber=353&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11716&amp;EndingColumnNumber=55&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491666546.943625"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11927&amp;EndingColumnNumber=64&amp;EndingLineNumber=361&amp;StartingColumnNumber=1&amp;StartingLineNumber=361&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=64&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.943798"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6791&amp;EndingColumnNumber=55&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6823&amp;EndingColumnNumber=55&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491666546.94397"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6618&amp;EndingColumnNumber=55&amp;EndingLineNumber=203&amp;StartingColumnNumber=1&amp;StartingLineNumber=203&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6650&amp;EndingColumnNumber=55&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=491666546.944146"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=6988&amp;EndingColumnNumber=48&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=7&amp;CharacterRangeLoc=7020&amp;EndingColumnNumber=31&amp;EndingLineNumber=216&amp;StartingColumnNumber=24&amp;StartingLineNumber=216&amp;Timestamp=491666546.966425"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9450&amp;EndingColumnNumber=49&amp;EndingLineNumber=281&amp;StartingColumnNumber=1&amp;StartingLineNumber=281&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9523&amp;EndingColumnNumber=49&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491666546.944525"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=2052&amp;EndingColumnNumber=22&amp;EndingLineNumber=71&amp;StartingColumnNumber=1&amp;StartingLineNumber=71&amp;Timestamp=452626605.5713"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=2068&amp;EndingColumnNumber=22&amp;EndingLineNumber=73&amp;StartingColumnNumber=1&amp;StartingLineNumber=73&amp;Timestamp=491666048.016322"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=2136&amp;EndingColumnNumber=43&amp;EndingLineNumber=74&amp;StartingColumnNumber=1&amp;StartingLineNumber=74&amp;Timestamp=452626605.5713"
+         documentLocation = "#CharacterRangeLen=42&amp;CharacterRangeLoc=2152&amp;EndingColumnNumber=43&amp;EndingLineNumber=76&amp;StartingColumnNumber=1&amp;StartingLineNumber=76&amp;Timestamp=491666048.016443"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3175&amp;EndingColumnNumber=64&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3191&amp;EndingColumnNumber=64&amp;EndingLineNumber=109&amp;StartingColumnNumber=1&amp;StartingLineNumber=109&amp;Timestamp=491666048.016568"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4356&amp;EndingColumnNumber=54&amp;EndingLineNumber=148&amp;StartingColumnNumber=1&amp;StartingLineNumber=148&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4372&amp;EndingColumnNumber=54&amp;EndingLineNumber=150&amp;StartingColumnNumber=1&amp;StartingLineNumber=150&amp;Timestamp=491666048.016693"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4154&amp;EndingColumnNumber=48&amp;EndingLineNumber=142&amp;StartingColumnNumber=1&amp;StartingLineNumber=142&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4170&amp;EndingColumnNumber=48&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=491666048.016817"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3957&amp;EndingColumnNumber=55&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3973&amp;EndingColumnNumber=55&amp;EndingLineNumber=136&amp;StartingColumnNumber=1&amp;StartingLineNumber=136&amp;Timestamp=491666048.016956"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=120&amp;CharacterRangeLoc=3716&amp;EndingColumnNumber=55&amp;EndingLineNumber=127&amp;StartingColumnNumber=1&amp;StartingLineNumber=127&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=120&amp;CharacterRangeLoc=3732&amp;EndingColumnNumber=55&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=491666048.017092"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3525&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3541&amp;EndingColumnNumber=64&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=491666048.017229"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=39&amp;CharacterRangeLoc=4664&amp;EndingColumnNumber=39&amp;EndingLineNumber=154&amp;StartingColumnNumber=1&amp;StartingLineNumber=154&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=39&amp;CharacterRangeLoc=4680&amp;EndingColumnNumber=39&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=491666546.946068"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6683&amp;EndingColumnNumber=63&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6715&amp;EndingColumnNumber=63&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=248&amp;Timestamp=491666546.946245"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6443&amp;EndingColumnNumber=60&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6475&amp;EndingColumnNumber=60&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.94642"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6250&amp;EndingColumnNumber=61&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6282&amp;EndingColumnNumber=61&amp;EndingLineNumber=221&amp;StartingColumnNumber=1&amp;StartingLineNumber=221&amp;Timestamp=491666546.946597"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=6057&amp;EndingColumnNumber=51&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=6089&amp;EndingColumnNumber=51&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=491666546.946769"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5879&amp;EndingColumnNumber=34&amp;EndingLineNumber=200&amp;StartingColumnNumber=21&amp;StartingLineNumber=200&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5911&amp;EndingColumnNumber=34&amp;EndingLineNumber=204&amp;StartingColumnNumber=21&amp;StartingLineNumber=204&amp;Timestamp=491666546.946966"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5707&amp;EndingColumnNumber=58&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5739&amp;EndingColumnNumber=58&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491666546.947193"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5537&amp;EndingColumnNumber=50&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5569&amp;EndingColumnNumber=50&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491666546.947442"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5381&amp;EndingColumnNumber=44&amp;EndingLineNumber=190&amp;StartingColumnNumber=1&amp;StartingLineNumber=190&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5413&amp;EndingColumnNumber=44&amp;EndingLineNumber=194&amp;StartingColumnNumber=1&amp;StartingLineNumber=194&amp;Timestamp=491666546.947723"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5216&amp;EndingColumnNumber=63&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5248&amp;EndingColumnNumber=63&amp;EndingLineNumber=188&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491666546.947968"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=8856&amp;EndingColumnNumber=55&amp;EndingLineNumber=267&amp;StartingColumnNumber=1&amp;StartingLineNumber=267&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=68&amp;CharacterRangeLoc=8896&amp;EndingColumnNumber=55&amp;EndingLineNumber=277&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=491666546.948187"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=239&amp;CharacterRangeLoc=8526&amp;EndingColumnNumber=53&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=234&amp;CharacterRangeLoc=8572&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948406"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8506&amp;EndingColumnNumber=54&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8572&amp;EndingColumnNumber=54&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948626"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=8379&amp;EndingColumnNumber=55&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=69&amp;CharacterRangeLoc=8411&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948852"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7202&amp;EndingColumnNumber=47&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7234&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.949076"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7094&amp;EndingColumnNumber=46&amp;EndingLineNumber=258&amp;StartingColumnNumber=1&amp;StartingLineNumber=258&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7126&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=491666546.949298"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7086&amp;EndingColumnNumber=55&amp;EndingLineNumber=246&amp;StartingColumnNumber=1&amp;StartingLineNumber=246&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7118&amp;EndingColumnNumber=55&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=250&amp;Timestamp=491666546.949524"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6943&amp;EndingColumnNumber=53&amp;EndingLineNumber=241&amp;StartingColumnNumber=1&amp;StartingLineNumber=241&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6975&amp;EndingColumnNumber=53&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491666546.949737"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6790&amp;EndingColumnNumber=34&amp;EndingLineNumber=207&amp;StartingColumnNumber=19&amp;StartingLineNumber=207&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6822&amp;EndingColumnNumber=34&amp;EndingLineNumber=211&amp;StartingColumnNumber=19&amp;StartingLineNumber=211&amp;Timestamp=491666546.949932"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6679&amp;EndingColumnNumber=55&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6711&amp;EndingColumnNumber=55&amp;EndingLineNumber=235&amp;StartingColumnNumber=1&amp;StartingLineNumber=235&amp;Timestamp=491666546.950116"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6555&amp;EndingColumnNumber=47&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6587&amp;EndingColumnNumber=47&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491666546.950296"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6448&amp;EndingColumnNumber=46&amp;EndingLineNumber=220&amp;StartingColumnNumber=1&amp;StartingLineNumber=220&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6480&amp;EndingColumnNumber=46&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=491666546.950432"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6038&amp;EndingColumnNumber=63&amp;EndingLineNumber=205&amp;StartingColumnNumber=1&amp;StartingLineNumber=205&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6070&amp;EndingColumnNumber=63&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=491666546.950544"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5798&amp;EndingColumnNumber=60&amp;EndingLineNumber=198&amp;StartingColumnNumber=1&amp;StartingLineNumber=198&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5830&amp;EndingColumnNumber=60&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491666546.950649"
          lockedSize = "{461, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5597&amp;EndingColumnNumber=61&amp;EndingLineNumber=192&amp;StartingColumnNumber=1&amp;StartingLineNumber=192&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5629&amp;EndingColumnNumber=61&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=491666546.950758"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5403&amp;EndingColumnNumber=51&amp;EndingLineNumber=186&amp;StartingColumnNumber=1&amp;StartingLineNumber=186&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5435&amp;EndingColumnNumber=51&amp;EndingLineNumber=190&amp;StartingColumnNumber=1&amp;StartingLineNumber=190&amp;Timestamp=491666546.95086"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5225&amp;EndingColumnNumber=58&amp;EndingLineNumber=180&amp;StartingColumnNumber=1&amp;StartingLineNumber=180&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5257&amp;EndingColumnNumber=58&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=491666546.950964"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5053&amp;EndingColumnNumber=58&amp;EndingLineNumber=174&amp;StartingColumnNumber=1&amp;StartingLineNumber=174&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5085&amp;EndingColumnNumber=58&amp;EndingLineNumber=178&amp;StartingColumnNumber=1&amp;StartingLineNumber=178&amp;Timestamp=491666546.951066"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4889&amp;EndingColumnNumber=44&amp;EndingLineNumber=168&amp;StartingColumnNumber=1&amp;StartingLineNumber=168&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4921&amp;EndingColumnNumber=44&amp;EndingLineNumber=172&amp;StartingColumnNumber=1&amp;StartingLineNumber=172&amp;Timestamp=491666546.95117"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4515&amp;EndingColumnNumber=24&amp;EndingLineNumber=155&amp;StartingColumnNumber=1&amp;StartingLineNumber=155&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4531&amp;EndingColumnNumber=24&amp;EndingLineNumber=159&amp;StartingColumnNumber=1&amp;StartingLineNumber=159&amp;Timestamp=491666546.951273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7085&amp;EndingColumnNumber=55&amp;EndingLineNumber=240&amp;StartingColumnNumber=1&amp;StartingLineNumber=240&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7117&amp;EndingColumnNumber=55&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=491666546.951381"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6942&amp;EndingColumnNumber=53&amp;EndingLineNumber=235&amp;StartingColumnNumber=1&amp;StartingLineNumber=235&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6974&amp;EndingColumnNumber=53&amp;EndingLineNumber=239&amp;StartingColumnNumber=1&amp;StartingLineNumber=239&amp;Timestamp=491666546.951484"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6789&amp;EndingColumnNumber=54&amp;EndingLineNumber=229&amp;StartingColumnNumber=1&amp;StartingLineNumber=229&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6821&amp;EndingColumnNumber=54&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=491666546.951587"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6678&amp;EndingColumnNumber=55&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6710&amp;EndingColumnNumber=55&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491666546.951765"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6554&amp;EndingColumnNumber=47&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6586&amp;EndingColumnNumber=47&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.951947"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6447&amp;EndingColumnNumber=55&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6479&amp;EndingColumnNumber=55&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=491666546.952128"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6037&amp;EndingColumnNumber=63&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6069&amp;EndingColumnNumber=63&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.952308"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5796&amp;EndingColumnNumber=61&amp;EndingLineNumber=197&amp;StartingColumnNumber=1&amp;StartingLineNumber=197&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5828&amp;EndingColumnNumber=61&amp;EndingLineNumber=201&amp;StartingColumnNumber=1&amp;StartingLineNumber=201&amp;Timestamp=491666546.952488"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5602&amp;EndingColumnNumber=51&amp;EndingLineNumber=191&amp;StartingColumnNumber=1&amp;StartingLineNumber=191&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5634&amp;EndingColumnNumber=51&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=491666546.952669"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5424&amp;EndingColumnNumber=58&amp;EndingLineNumber=185&amp;StartingColumnNumber=1&amp;StartingLineNumber=185&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5456&amp;EndingColumnNumber=58&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=189&amp;Timestamp=491666546.952853"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5252&amp;EndingColumnNumber=58&amp;EndingLineNumber=179&amp;StartingColumnNumber=1&amp;StartingLineNumber=179&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5284&amp;EndingColumnNumber=58&amp;EndingLineNumber=183&amp;StartingColumnNumber=1&amp;StartingLineNumber=183&amp;Timestamp=491666546.952967"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5088&amp;EndingColumnNumber=44&amp;EndingLineNumber=173&amp;StartingColumnNumber=1&amp;StartingLineNumber=173&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5120&amp;EndingColumnNumber=44&amp;EndingLineNumber=177&amp;StartingColumnNumber=1&amp;StartingLineNumber=177&amp;Timestamp=491666546.953073"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4716&amp;EndingColumnNumber=24&amp;EndingLineNumber=161&amp;StartingColumnNumber=1&amp;StartingLineNumber=161&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4732&amp;EndingColumnNumber=24&amp;EndingLineNumber=165&amp;StartingColumnNumber=1&amp;StartingLineNumber=165&amp;Timestamp=491666546.953179"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4523&amp;EndingColumnNumber=60&amp;EndingLineNumber=152&amp;StartingColumnNumber=1&amp;StartingLineNumber=152&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4539&amp;EndingColumnNumber=60&amp;EndingLineNumber=156&amp;StartingColumnNumber=1&amp;StartingLineNumber=156&amp;Timestamp=491666546.953282"
          lockedSize = "{426, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4329&amp;EndingColumnNumber=54&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4345&amp;EndingColumnNumber=54&amp;EndingLineNumber=148&amp;StartingColumnNumber=1&amp;StartingLineNumber=148&amp;Timestamp=491666048.022888"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3929&amp;EndingColumnNumber=55&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=452640965.967315"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3945&amp;EndingColumnNumber=55&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=491666048.023001"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3688&amp;EndingColumnNumber=56&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3704&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491666048.023112"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3497&amp;EndingColumnNumber=64&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3513&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491666048.023226"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3154&amp;EndingColumnNumber=63&amp;EndingLineNumber=105&amp;StartingColumnNumber=1&amp;StartingLineNumber=105&amp;Timestamp=452640855.88518"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3170&amp;EndingColumnNumber=63&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=491666048.02334"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6691&amp;EndingColumnNumber=53&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6723&amp;EndingColumnNumber=53&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491666546.953906"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6560&amp;EndingColumnNumber=54&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6592&amp;EndingColumnNumber=54&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.95401"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6323&amp;EndingColumnNumber=47&amp;EndingLineNumber=215&amp;StartingColumnNumber=1&amp;StartingLineNumber=215&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6355&amp;EndingColumnNumber=47&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491666546.954112"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6216&amp;EndingColumnNumber=46&amp;EndingLineNumber=211&amp;StartingColumnNumber=1&amp;StartingLineNumber=211&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6248&amp;EndingColumnNumber=46&amp;EndingLineNumber=215&amp;StartingColumnNumber=1&amp;StartingLineNumber=215&amp;Timestamp=491666546.954214"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5806&amp;EndingColumnNumber=63&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5838&amp;EndingColumnNumber=63&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491666546.954318"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5565&amp;EndingColumnNumber=61&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=189&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5597&amp;EndingColumnNumber=61&amp;EndingLineNumber=193&amp;StartingColumnNumber=1&amp;StartingLineNumber=193&amp;Timestamp=491666546.954422"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5371&amp;EndingColumnNumber=51&amp;EndingLineNumber=183&amp;StartingColumnNumber=1&amp;StartingLineNumber=183&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5403&amp;EndingColumnNumber=51&amp;EndingLineNumber=187&amp;StartingColumnNumber=1&amp;StartingLineNumber=187&amp;Timestamp=491666546.954526"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5193&amp;EndingColumnNumber=58&amp;EndingLineNumber=177&amp;StartingColumnNumber=1&amp;StartingLineNumber=177&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5225&amp;EndingColumnNumber=58&amp;EndingLineNumber=181&amp;StartingColumnNumber=1&amp;StartingLineNumber=181&amp;Timestamp=491666546.954627"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5035&amp;EndingColumnNumber=44&amp;EndingLineNumber=171&amp;StartingColumnNumber=1&amp;StartingLineNumber=171&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5067&amp;EndingColumnNumber=44&amp;EndingLineNumber=175&amp;StartingColumnNumber=1&amp;StartingLineNumber=175&amp;Timestamp=491666546.954729"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4662&amp;EndingColumnNumber=24&amp;EndingLineNumber=159&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=452685550.893821"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4678&amp;EndingColumnNumber=24&amp;EndingLineNumber=163&amp;StartingColumnNumber=1&amp;StartingLineNumber=162&amp;Timestamp=491666546.954833"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4470&amp;EndingColumnNumber=60&amp;EndingLineNumber=150&amp;StartingColumnNumber=1&amp;StartingLineNumber=150&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4486&amp;EndingColumnNumber=60&amp;EndingLineNumber=153&amp;StartingColumnNumber=1&amp;StartingLineNumber=152&amp;Timestamp=491666540.521503"
          lockedSize = "{458, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3876&amp;EndingColumnNumber=55&amp;EndingLineNumber=130&amp;StartingColumnNumber=1&amp;StartingLineNumber=130&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3892&amp;EndingColumnNumber=55&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=491666048.024683"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3700&amp;EndingColumnNumber=56&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3716&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491666048.0248"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3509&amp;EndingColumnNumber=64&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3525&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491666048.024913"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3166&amp;EndingColumnNumber=63&amp;EndingLineNumber=105&amp;StartingColumnNumber=1&amp;StartingLineNumber=105&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3182&amp;EndingColumnNumber=63&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=491666048.025027"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4276&amp;EndingColumnNumber=54&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4292&amp;EndingColumnNumber=54&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=491666048.025139"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4073&amp;EndingColumnNumber=48&amp;EndingLineNumber=138&amp;StartingColumnNumber=1&amp;StartingLineNumber=138&amp;Timestamp=452641054.5667"
+         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4089&amp;EndingColumnNumber=48&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491666048.025251"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=491818311.833423"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=493546199.797659"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -88,55 +88,55 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491818305.033168"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=319&amp;StartingColumnNumber=12&amp;StartingLineNumber=319&amp;Timestamp=493545754.3009"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491818305.033293"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=319&amp;StartingColumnNumber=12&amp;StartingLineNumber=319&amp;Timestamp=493545754.301026"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.033415"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=305&amp;StartingColumnNumber=1&amp;StartingLineNumber=305&amp;Timestamp=493545754.301148"
          lockedSize = "{720, 71}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=329&amp;StartingColumnNumber=1&amp;StartingLineNumber=329&amp;Timestamp=491818305.033541"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=334&amp;StartingColumnNumber=1&amp;StartingLineNumber=334&amp;Timestamp=493545754.301276"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=315&amp;StartingColumnNumber=12&amp;StartingLineNumber=315&amp;Timestamp=491818305.033677"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=320&amp;StartingColumnNumber=12&amp;StartingLineNumber=320&amp;Timestamp=493545754.301399"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=333&amp;StartingColumnNumber=1&amp;StartingLineNumber=333&amp;Timestamp=491818305.0338"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=338&amp;StartingColumnNumber=1&amp;StartingLineNumber=338&amp;Timestamp=493545754.301521"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=343&amp;StartingColumnNumber=1&amp;StartingLineNumber=343&amp;Timestamp=491818305.033922"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=348&amp;StartingColumnNumber=1&amp;StartingLineNumber=348&amp;Timestamp=493545754.301643"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=360&amp;StartingColumnNumber=1&amp;StartingLineNumber=360&amp;Timestamp=491818305.034045"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=365&amp;StartingColumnNumber=1&amp;StartingLineNumber=365&amp;Timestamp=493545754.301765"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491818305.034173"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=368&amp;StartingColumnNumber=1&amp;StartingLineNumber=368&amp;Timestamp=493545754.301893"
          lockedSize = "{489, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=21&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.836707"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=21&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.801464"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -214,34 +214,34 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1411&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.036102"
+         documentLocation = "#CharacterRangeLen=1411&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=23&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.304172"
          lockedSize = "{421, 73}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.03623"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=23&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.304306"
          lockedSize = "{765, 78}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=8&amp;EndingLineNumber=278&amp;StartingColumnNumber=5&amp;StartingLineNumber=278&amp;Timestamp=491818305.036372"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=8&amp;EndingLineNumber=283&amp;StartingColumnNumber=5&amp;StartingLineNumber=283&amp;Timestamp=493545754.304432"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.036497"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=305&amp;StartingColumnNumber=1&amp;StartingLineNumber=305&amp;Timestamp=493545754.304554"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=308&amp;StartingColumnNumber=1&amp;StartingLineNumber=308&amp;Timestamp=491818305.036617"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=313&amp;StartingColumnNumber=1&amp;StartingLineNumber=313&amp;Timestamp=493545754.30467"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=311&amp;StartingColumnNumber=1&amp;StartingLineNumber=311&amp;Timestamp=491818305.036738"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=316&amp;StartingColumnNumber=1&amp;StartingLineNumber=316&amp;Timestamp=493545754.304787"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -278,17 +278,17 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.037582"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.305584"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.03771"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.3057"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.037823"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.305816"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -343,7 +343,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=342&amp;StartingColumnNumber=1&amp;StartingLineNumber=342&amp;Timestamp=491818305.039064"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=347&amp;StartingColumnNumber=1&amp;StartingLineNumber=347&amp;Timestamp=493545754.30703"
          lockedSize = "{520, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -361,19 +361,19 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.039416"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.307382"
          lockedSize = "{550, 94}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.039533"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.3075"
          lockedSize = "{543, 83}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=278&amp;Timestamp=491818305.039657"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=283&amp;StartingColumnNumber=1&amp;StartingLineNumber=283&amp;Timestamp=493545754.30762"
          lockedSize = "{544, 89}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -411,121 +411,121 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=58&amp;EndingLineNumber=199&amp;StartingColumnNumber=1&amp;StartingLineNumber=199&amp;Timestamp=491818305.040449"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=58&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=493545754.308439"
          lockedSize = "{416, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=17&amp;EndingLineNumber=254&amp;StartingColumnNumber=5&amp;StartingLineNumber=254&amp;Timestamp=491818305.040582"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=17&amp;EndingLineNumber=259&amp;StartingColumnNumber=5&amp;StartingLineNumber=259&amp;Timestamp=493545754.308549"
          lockedSize = "{815, 67}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=281&amp;StartingColumnNumber=1&amp;StartingLineNumber=281&amp;Timestamp=491818305.040699"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=286&amp;StartingColumnNumber=1&amp;StartingLineNumber=286&amp;Timestamp=493545754.308655"
          lockedSize = "{548, 85}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.040815"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=287&amp;StartingColumnNumber=1&amp;StartingLineNumber=287&amp;Timestamp=493545754.30876"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.040928"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=287&amp;StartingColumnNumber=1&amp;StartingLineNumber=287&amp;Timestamp=493545754.308862"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=30&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.041038"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=30&amp;EndingLineNumber=287&amp;StartingColumnNumber=1&amp;StartingLineNumber=287&amp;Timestamp=493545754.308963"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=3&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491818305.04115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=3&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=493545754.309065"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491818305.041264"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=493545754.309168"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.041377"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=287&amp;StartingColumnNumber=1&amp;StartingLineNumber=287&amp;Timestamp=493545754.309269"
          lockedSize = "{548, 75}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=65&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491818305.041492"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=65&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=493545754.309373"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491818305.041707"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=211&amp;StartingColumnNumber=1&amp;StartingLineNumber=211&amp;Timestamp=493545754.309477"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=55&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844373"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=55&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.809705"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844516"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=56&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.809833"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844635"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=56&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.809958"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.84475"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=56&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.810083"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=3&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844865"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=3&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.810209"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=12&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844978"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=12&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.810333"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.04306"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.310438"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.043248"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.310541"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=265&amp;StartingColumnNumber=1&amp;StartingLineNumber=265&amp;Timestamp=491818305.043438"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=270&amp;StartingColumnNumber=1&amp;StartingLineNumber=270&amp;Timestamp=493545754.310644"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=261&amp;StartingColumnNumber=1&amp;StartingLineNumber=261&amp;Timestamp=491818305.04363"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=266&amp;StartingColumnNumber=1&amp;StartingLineNumber=266&amp;Timestamp=493545754.310748"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491818305.043822"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=259&amp;StartingColumnNumber=1&amp;StartingLineNumber=259&amp;Timestamp=493545754.31085"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=337&amp;CharacterRangeLoc=4441&amp;EndingColumnNumber=46&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.044011"
+         documentLocation = "#CharacterRangeLen=337&amp;CharacterRangeLoc=4441&amp;EndingColumnNumber=46&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=493545754.310953"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -579,28 +579,28 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=63&amp;EndingLineNumber=304&amp;StartingColumnNumber=1&amp;StartingLineNumber=304&amp;Timestamp=491818305.045821"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=63&amp;EndingLineNumber=309&amp;StartingColumnNumber=1&amp;StartingLineNumber=309&amp;Timestamp=493545754.311984"
          lockedSize = "{478, 60}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.045953"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=493545754.312107"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491818305.046075"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=493545754.312222"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=299&amp;StartingColumnNumber=1&amp;StartingLineNumber=299&amp;Timestamp=491818305.046197"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=304&amp;StartingColumnNumber=1&amp;StartingLineNumber=304&amp;Timestamp=493545754.312335"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=60&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.046318"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=60&amp;EndingLineNumber=305&amp;StartingColumnNumber=1&amp;StartingLineNumber=305&amp;Timestamp=493545754.312448"
          lockedSize = "{815, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -616,12 +616,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3579&amp;EndingColumnNumber=46&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491818305.046679"
+         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3579&amp;EndingColumnNumber=46&amp;EndingLineNumber=259&amp;StartingColumnNumber=1&amp;StartingLineNumber=259&amp;Timestamp=493545754.312787"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=64&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491818305.046802"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=64&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=493545754.3129"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -644,47 +644,47 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9384&amp;EndingColumnNumber=59&amp;EndingLineNumber=286&amp;StartingColumnNumber=1&amp;StartingLineNumber=286&amp;Timestamp=491818311.848353"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9487&amp;EndingColumnNumber=59&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=493546199.813692"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9327&amp;EndingColumnNumber=58&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=491818311.848462"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9430&amp;EndingColumnNumber=58&amp;EndingLineNumber=290&amp;StartingColumnNumber=1&amp;StartingLineNumber=290&amp;Timestamp=493546199.813823"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.848569"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=56&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.813939"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11698&amp;EndingColumnNumber=55&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491818311.848675"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11811&amp;EndingColumnNumber=55&amp;EndingLineNumber=368&amp;StartingColumnNumber=1&amp;StartingLineNumber=368&amp;Timestamp=493546199.814054"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=64&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.848778"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12095&amp;EndingColumnNumber=64&amp;EndingLineNumber=376&amp;StartingColumnNumber=1&amp;StartingLineNumber=376&amp;Timestamp=493546199.814168"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6814&amp;EndingColumnNumber=55&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491818305.048023"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6887&amp;EndingColumnNumber=55&amp;EndingLineNumber=218&amp;StartingColumnNumber=1&amp;StartingLineNumber=218&amp;Timestamp=493545754.313919"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6641&amp;EndingColumnNumber=55&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=491818305.048146"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6714&amp;EndingColumnNumber=55&amp;EndingLineNumber=212&amp;StartingColumnNumber=1&amp;StartingLineNumber=212&amp;Timestamp=493545754.314033"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=7&amp;CharacterRangeLoc=7011&amp;EndingColumnNumber=31&amp;EndingLineNumber=216&amp;StartingColumnNumber=24&amp;StartingLineNumber=216&amp;Timestamp=491818305.048267"
+         documentLocation = "#CharacterRangeLen=7&amp;CharacterRangeLoc=7084&amp;EndingColumnNumber=31&amp;EndingLineNumber=221&amp;StartingColumnNumber=24&amp;StartingLineNumber=221&amp;Timestamp=493545754.314147"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9505&amp;EndingColumnNumber=49&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491818311.849185"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9608&amp;EndingColumnNumber=49&amp;EndingLineNumber=296&amp;StartingColumnNumber=1&amp;StartingLineNumber=296&amp;Timestamp=493546199.814615"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -734,133 +734,133 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6706&amp;EndingColumnNumber=63&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=248&amp;Timestamp=491818305.049585"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6779&amp;EndingColumnNumber=63&amp;EndingLineNumber=253&amp;StartingColumnNumber=1&amp;StartingLineNumber=253&amp;Timestamp=493545754.315393"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6466&amp;EndingColumnNumber=60&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.049704"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6539&amp;EndingColumnNumber=60&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=493545754.315506"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6273&amp;EndingColumnNumber=61&amp;EndingLineNumber=221&amp;StartingColumnNumber=1&amp;StartingLineNumber=221&amp;Timestamp=491818305.049825"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6346&amp;EndingColumnNumber=61&amp;EndingLineNumber=226&amp;StartingColumnNumber=1&amp;StartingLineNumber=226&amp;Timestamp=493545754.315621"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=6080&amp;EndingColumnNumber=51&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=491818305.049943"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=6080&amp;EndingColumnNumber=51&amp;EndingLineNumber=222&amp;StartingColumnNumber=1&amp;StartingLineNumber=222&amp;Timestamp=493545754.315736"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5902&amp;EndingColumnNumber=34&amp;EndingLineNumber=204&amp;StartingColumnNumber=21&amp;StartingLineNumber=204&amp;Timestamp=491818305.050062"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5902&amp;EndingColumnNumber=34&amp;EndingLineNumber=209&amp;StartingColumnNumber=21&amp;StartingLineNumber=209&amp;Timestamp=493545754.315851"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5730&amp;EndingColumnNumber=58&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491818305.05018"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5730&amp;EndingColumnNumber=58&amp;EndingLineNumber=211&amp;StartingColumnNumber=1&amp;StartingLineNumber=211&amp;Timestamp=493545754.315967"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5560&amp;EndingColumnNumber=50&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491818305.050308"
+         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5560&amp;EndingColumnNumber=50&amp;EndingLineNumber=205&amp;StartingColumnNumber=1&amp;StartingLineNumber=205&amp;Timestamp=493545754.316084"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5404&amp;EndingColumnNumber=44&amp;EndingLineNumber=194&amp;StartingColumnNumber=1&amp;StartingLineNumber=194&amp;Timestamp=491818305.050456"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5404&amp;EndingColumnNumber=44&amp;EndingLineNumber=199&amp;StartingColumnNumber=1&amp;StartingLineNumber=199&amp;Timestamp=493545754.316199"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5239&amp;EndingColumnNumber=63&amp;EndingLineNumber=188&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491818305.050581"
+         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5239&amp;EndingColumnNumber=63&amp;EndingLineNumber=193&amp;StartingColumnNumber=1&amp;StartingLineNumber=193&amp;Timestamp=493545754.316314"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=68&amp;CharacterRangeLoc=8878&amp;EndingColumnNumber=55&amp;EndingLineNumber=277&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=491818311.851094"
+         documentLocation = "#CharacterRangeLen=68&amp;CharacterRangeLoc=8971&amp;EndingColumnNumber=55&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=493546189.935038"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=234&amp;CharacterRangeLoc=8554&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818311.851197"
+         documentLocation = "#CharacterRangeLen=234&amp;CharacterRangeLoc=8637&amp;EndingColumnNumber=53&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493546185.831045"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8554&amp;EndingColumnNumber=54&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818311.8513"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8637&amp;EndingColumnNumber=54&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493546185.831172"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=69&amp;CharacterRangeLoc=8402&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.051055"
+         documentLocation = "#CharacterRangeLen=79&amp;CharacterRangeLoc=8475&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493546185.831296"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7225&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.051176"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7298&amp;EndingColumnNumber=47&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=493545754.317515"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7117&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=491818305.051297"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7190&amp;EndingColumnNumber=46&amp;EndingLineNumber=269&amp;StartingColumnNumber=1&amp;StartingLineNumber=269&amp;Timestamp=493545754.317737"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7109&amp;EndingColumnNumber=55&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=250&amp;Timestamp=491818305.051418"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7182&amp;EndingColumnNumber=55&amp;EndingLineNumber=256&amp;StartingColumnNumber=1&amp;StartingLineNumber=255&amp;Timestamp=493545754.317925"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6966&amp;EndingColumnNumber=53&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491818305.051538"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=7039&amp;EndingColumnNumber=53&amp;EndingLineNumber=250&amp;StartingColumnNumber=1&amp;StartingLineNumber=250&amp;Timestamp=493545754.318117"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6813&amp;EndingColumnNumber=34&amp;EndingLineNumber=211&amp;StartingColumnNumber=19&amp;StartingLineNumber=211&amp;Timestamp=491818305.051662"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6886&amp;EndingColumnNumber=34&amp;EndingLineNumber=216&amp;StartingColumnNumber=19&amp;StartingLineNumber=216&amp;Timestamp=493545754.318354"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6702&amp;EndingColumnNumber=55&amp;EndingLineNumber=235&amp;StartingColumnNumber=1&amp;StartingLineNumber=235&amp;Timestamp=491818305.051783"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6775&amp;EndingColumnNumber=55&amp;EndingLineNumber=240&amp;StartingColumnNumber=1&amp;StartingLineNumber=240&amp;Timestamp=493545754.318526"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6578&amp;EndingColumnNumber=47&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491818305.051901"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6651&amp;EndingColumnNumber=47&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=493545754.318646"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6471&amp;EndingColumnNumber=46&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=491818305.052023"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6544&amp;EndingColumnNumber=46&amp;EndingLineNumber=229&amp;StartingColumnNumber=1&amp;StartingLineNumber=229&amp;Timestamp=493545754.318765"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6061&amp;EndingColumnNumber=63&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=491818305.052143"
+         documentLocation = "#CharacterRangeLen=38&amp;CharacterRangeLoc=6061&amp;EndingColumnNumber=63&amp;EndingLineNumber=214&amp;StartingColumnNumber=1&amp;StartingLineNumber=214&amp;Timestamp=493545754.318881"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5821&amp;EndingColumnNumber=60&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491818305.052263"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5821&amp;EndingColumnNumber=60&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=493545754.318998"
          lockedSize = "{461, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5620&amp;EndingColumnNumber=61&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=491818305.052389"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5620&amp;EndingColumnNumber=61&amp;EndingLineNumber=201&amp;StartingColumnNumber=1&amp;StartingLineNumber=201&amp;Timestamp=493545754.319119"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5426&amp;EndingColumnNumber=51&amp;EndingLineNumber=190&amp;StartingColumnNumber=1&amp;StartingLineNumber=190&amp;Timestamp=491818305.052508"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5426&amp;EndingColumnNumber=51&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=493545754.319239"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5248&amp;EndingColumnNumber=58&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=491818305.052661"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5248&amp;EndingColumnNumber=58&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=493545754.319419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -880,52 +880,52 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7108&amp;EndingColumnNumber=55&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=491818305.053144"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7181&amp;EndingColumnNumber=55&amp;EndingLineNumber=249&amp;StartingColumnNumber=1&amp;StartingLineNumber=249&amp;Timestamp=493545754.320207"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6965&amp;EndingColumnNumber=53&amp;EndingLineNumber=239&amp;StartingColumnNumber=1&amp;StartingLineNumber=239&amp;Timestamp=491818305.053263"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=7038&amp;EndingColumnNumber=53&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=493545754.320418"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6812&amp;EndingColumnNumber=54&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=491818305.053381"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6885&amp;EndingColumnNumber=54&amp;EndingLineNumber=238&amp;StartingColumnNumber=1&amp;StartingLineNumber=238&amp;Timestamp=493545754.320638"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6701&amp;EndingColumnNumber=55&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491818305.053499"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6774&amp;EndingColumnNumber=55&amp;EndingLineNumber=236&amp;StartingColumnNumber=1&amp;StartingLineNumber=236&amp;Timestamp=493545754.32077"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6577&amp;EndingColumnNumber=47&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.053618"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6650&amp;EndingColumnNumber=47&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=493545754.320897"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6470&amp;EndingColumnNumber=55&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=491818305.053744"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6543&amp;EndingColumnNumber=55&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=493545754.321025"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6060&amp;EndingColumnNumber=63&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.053857"
+         documentLocation = "#CharacterRangeLen=39&amp;CharacterRangeLoc=6060&amp;EndingColumnNumber=63&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=493545754.321151"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5819&amp;EndingColumnNumber=61&amp;EndingLineNumber=201&amp;StartingColumnNumber=1&amp;StartingLineNumber=201&amp;Timestamp=491818305.053968"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5819&amp;EndingColumnNumber=61&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=493545754.321275"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5625&amp;EndingColumnNumber=51&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=491818305.054079"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5625&amp;EndingColumnNumber=51&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=493545754.321398"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5447&amp;EndingColumnNumber=58&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=189&amp;Timestamp=491818305.054192"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5447&amp;EndingColumnNumber=58&amp;EndingLineNumber=194&amp;StartingColumnNumber=1&amp;StartingLineNumber=194&amp;Timestamp=493545754.321522"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -976,37 +976,37 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6714&amp;EndingColumnNumber=53&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491818305.055297"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6787&amp;EndingColumnNumber=53&amp;EndingLineNumber=236&amp;StartingColumnNumber=1&amp;StartingLineNumber=236&amp;Timestamp=493545754.322724"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6583&amp;EndingColumnNumber=54&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.055408"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6656&amp;EndingColumnNumber=54&amp;EndingLineNumber=232&amp;StartingColumnNumber=1&amp;StartingLineNumber=232&amp;Timestamp=493545754.322848"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6346&amp;EndingColumnNumber=47&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491818305.055518"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6419&amp;EndingColumnNumber=47&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=493545754.32297"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6239&amp;EndingColumnNumber=46&amp;EndingLineNumber=215&amp;StartingColumnNumber=1&amp;StartingLineNumber=215&amp;Timestamp=491818305.055628"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6312&amp;EndingColumnNumber=46&amp;EndingLineNumber=220&amp;StartingColumnNumber=1&amp;StartingLineNumber=220&amp;Timestamp=493545754.323093"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5829&amp;EndingColumnNumber=63&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491818305.055739"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5829&amp;EndingColumnNumber=63&amp;EndingLineNumber=205&amp;StartingColumnNumber=1&amp;StartingLineNumber=205&amp;Timestamp=493545754.323217"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5588&amp;EndingColumnNumber=61&amp;EndingLineNumber=193&amp;StartingColumnNumber=1&amp;StartingLineNumber=193&amp;Timestamp=491818305.05585"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5588&amp;EndingColumnNumber=61&amp;EndingLineNumber=198&amp;StartingColumnNumber=1&amp;StartingLineNumber=198&amp;Timestamp=493545754.323339"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5394&amp;EndingColumnNumber=51&amp;EndingLineNumber=187&amp;StartingColumnNumber=1&amp;StartingLineNumber=187&amp;Timestamp=491818305.05596"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5394&amp;EndingColumnNumber=51&amp;EndingLineNumber=192&amp;StartingColumnNumber=1&amp;StartingLineNumber=192&amp;Timestamp=493545754.323462"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
+++ b/Playgrounds/5b_More_flatMap_for_Squirrels.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=491666546.921066"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=1&amp;EndingLineNumber=3&amp;StartingColumnNumber=1&amp;StartingLineNumber=3&amp;Timestamp=491818311.833423"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -88,55 +88,55 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491666546.92398"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491818305.033168"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491666546.924163"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=314&amp;StartingColumnNumber=12&amp;StartingLineNumber=314&amp;Timestamp=491818305.033293"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.924354"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.033415"
          lockedSize = "{720, 71}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=329&amp;StartingColumnNumber=1&amp;StartingLineNumber=329&amp;Timestamp=491666546.924554"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=329&amp;StartingColumnNumber=1&amp;StartingLineNumber=329&amp;Timestamp=491818305.033541"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=315&amp;StartingColumnNumber=12&amp;StartingLineNumber=315&amp;Timestamp=491666546.924747"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=315&amp;StartingColumnNumber=12&amp;StartingLineNumber=315&amp;Timestamp=491818305.033677"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=13&amp;EndingLineNumber=333&amp;StartingColumnNumber=1&amp;StartingLineNumber=333&amp;Timestamp=491666546.924942"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=333&amp;StartingColumnNumber=1&amp;StartingLineNumber=333&amp;Timestamp=491818305.0338"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=13&amp;EndingLineNumber=343&amp;StartingColumnNumber=1&amp;StartingLineNumber=343&amp;Timestamp=491666546.925133"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=13&amp;EndingLineNumber=343&amp;StartingColumnNumber=1&amp;StartingLineNumber=343&amp;Timestamp=491818305.033922"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=360&amp;StartingColumnNumber=1&amp;StartingLineNumber=360&amp;Timestamp=491666546.925323"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=360&amp;StartingColumnNumber=1&amp;StartingLineNumber=360&amp;Timestamp=491818305.034045"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=22&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491666546.925523"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491818305.034173"
          lockedSize = "{489, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=21&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.925726"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=21&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.836707"
          lockedSize = "{485, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -147,7 +147,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=11&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491666539.873498"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=11&amp;EndingLineNumber=106&amp;StartingColumnNumber=1&amp;StartingLineNumber=106&amp;Timestamp=491818305.034548"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -214,34 +214,34 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1411&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.928401"
+         documentLocation = "#CharacterRangeLen=1411&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.036102"
          lockedSize = "{421, 73}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.928593"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=23&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.03623"
          lockedSize = "{765, 78}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=8&amp;EndingLineNumber=278&amp;StartingColumnNumber=5&amp;StartingLineNumber=278&amp;Timestamp=491666546.928776"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=8&amp;EndingLineNumber=278&amp;StartingColumnNumber=5&amp;StartingLineNumber=278&amp;Timestamp=491818305.036372"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.928957"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.036497"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=22&amp;EndingLineNumber=308&amp;StartingColumnNumber=1&amp;StartingLineNumber=308&amp;Timestamp=491666546.929134"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=22&amp;EndingLineNumber=308&amp;StartingColumnNumber=1&amp;StartingLineNumber=308&amp;Timestamp=491818305.036617"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=311&amp;StartingColumnNumber=1&amp;StartingLineNumber=311&amp;Timestamp=491666546.929311"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=311&amp;StartingColumnNumber=1&amp;StartingLineNumber=311&amp;Timestamp=491818305.036738"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -278,22 +278,22 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.930602"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.037582"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.930782"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.03771"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.93097"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.037823"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=51&amp;EndingLineNumber=167&amp;StartingColumnNumber=1&amp;StartingLineNumber=167&amp;Timestamp=491666546.931163"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=51&amp;EndingLineNumber=167&amp;StartingColumnNumber=1&amp;StartingLineNumber=167&amp;Timestamp=491818305.037935"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -343,13 +343,13 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=61&amp;EndingLineNumber=342&amp;StartingColumnNumber=1&amp;StartingLineNumber=342&amp;Timestamp=491666546.933009"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=342&amp;StartingColumnNumber=1&amp;StartingLineNumber=342&amp;Timestamp=491818305.039064"
          lockedSize = "{520, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=20&amp;EndingLineNumber=141&amp;StartingColumnNumber=13&amp;StartingLineNumber=141&amp;Timestamp=491666048.007304"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=20&amp;EndingLineNumber=141&amp;StartingColumnNumber=13&amp;StartingLineNumber=141&amp;Timestamp=491818305.039183"
          lockedSize = "{415, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -361,25 +361,25 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.933574"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=46&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.039416"
          lockedSize = "{550, 94}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.933766"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.039533"
          lockedSize = "{543, 83}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=278&amp;Timestamp=491666546.933956"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=278&amp;StartingColumnNumber=1&amp;StartingLineNumber=278&amp;Timestamp=491818305.039657"
          lockedSize = "{544, 89}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=18&amp;EndingLineNumber=139&amp;StartingColumnNumber=5&amp;StartingLineNumber=139&amp;Timestamp=491666048.007927"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=18&amp;EndingLineNumber=139&amp;StartingColumnNumber=5&amp;StartingLineNumber=139&amp;Timestamp=491818305.039777"
          lockedSize = "{420, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -411,121 +411,121 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=58&amp;EndingLineNumber=199&amp;StartingColumnNumber=1&amp;StartingLineNumber=199&amp;Timestamp=491666546.935245"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=58&amp;EndingLineNumber=199&amp;StartingColumnNumber=1&amp;StartingLineNumber=199&amp;Timestamp=491818305.040449"
          lockedSize = "{416, 56}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=17&amp;EndingLineNumber=254&amp;StartingColumnNumber=5&amp;StartingLineNumber=254&amp;Timestamp=491666546.935437"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=17&amp;EndingLineNumber=254&amp;StartingColumnNumber=5&amp;StartingLineNumber=254&amp;Timestamp=491818305.040582"
          lockedSize = "{815, 67}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=281&amp;StartingColumnNumber=1&amp;StartingLineNumber=281&amp;Timestamp=491666546.935619"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=281&amp;StartingColumnNumber=1&amp;StartingLineNumber=281&amp;Timestamp=491818305.040699"
          lockedSize = "{548, 85}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.935799"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.040815"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=21&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.935977"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=21&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.040928"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=30&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.936152"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=30&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.041038"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=3&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491666546.936327"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=3&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491818305.04115"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=12&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491666546.936503"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=12&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=491818305.041264"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491666546.936679"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=282&amp;StartingColumnNumber=1&amp;StartingLineNumber=282&amp;Timestamp=491818305.041377"
          lockedSize = "{548, 75}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=65&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491666546.936861"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=65&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491818305.041492"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=54&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491666546.937045"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491818305.041707"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=55&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937221"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=55&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844373"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937397"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844516"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937572"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844635"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937747"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.84475"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=3&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.937931"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=3&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844865"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=12&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.938111"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=12&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.844978"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.938291"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.04306"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.938471"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.043248"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=54&amp;EndingLineNumber=265&amp;StartingColumnNumber=1&amp;StartingLineNumber=265&amp;Timestamp=491666546.938653"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=54&amp;EndingLineNumber=265&amp;StartingColumnNumber=1&amp;StartingLineNumber=265&amp;Timestamp=491818305.043438"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=261&amp;StartingColumnNumber=1&amp;StartingLineNumber=261&amp;Timestamp=491666546.938832"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=261&amp;StartingColumnNumber=1&amp;StartingLineNumber=261&amp;Timestamp=491818305.04363"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=47&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491666546.939012"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=47&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491818305.043822"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=337&amp;CharacterRangeLoc=4450&amp;EndingColumnNumber=46&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.939191"
+         documentLocation = "#CharacterRangeLen=337&amp;CharacterRangeLoc=4441&amp;EndingColumnNumber=46&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.044011"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -579,28 +579,28 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=63&amp;EndingLineNumber=304&amp;StartingColumnNumber=1&amp;StartingLineNumber=304&amp;Timestamp=491666546.940976"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=63&amp;EndingLineNumber=304&amp;StartingColumnNumber=1&amp;StartingLineNumber=304&amp;Timestamp=491818305.045821"
          lockedSize = "{478, 60}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.941164"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.045953"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=55&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491666546.94134"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=55&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491818305.046075"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=61&amp;EndingLineNumber=299&amp;StartingColumnNumber=1&amp;StartingLineNumber=299&amp;Timestamp=491666546.941517"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=61&amp;EndingLineNumber=299&amp;StartingColumnNumber=1&amp;StartingLineNumber=299&amp;Timestamp=491818305.046197"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4787&amp;EndingColumnNumber=60&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491666546.94169"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=4778&amp;EndingColumnNumber=60&amp;EndingLineNumber=300&amp;StartingColumnNumber=1&amp;StartingLineNumber=300&amp;Timestamp=491818305.046318"
          lockedSize = "{815, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -616,12 +616,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3588&amp;EndingColumnNumber=46&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491666546.942216"
+         documentLocation = "#CharacterRangeLen=48&amp;CharacterRangeLoc=3579&amp;EndingColumnNumber=46&amp;EndingLineNumber=254&amp;StartingColumnNumber=1&amp;StartingLineNumber=254&amp;Timestamp=491818305.046679"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3376&amp;EndingColumnNumber=64&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491666546.942394"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=3367&amp;EndingColumnNumber=64&amp;EndingLineNumber=204&amp;StartingColumnNumber=1&amp;StartingLineNumber=204&amp;Timestamp=491818305.046802"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -644,47 +644,47 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9402&amp;EndingColumnNumber=59&amp;EndingLineNumber=286&amp;StartingColumnNumber=1&amp;StartingLineNumber=286&amp;Timestamp=491666546.943096"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=9384&amp;EndingColumnNumber=59&amp;EndingLineNumber=286&amp;StartingColumnNumber=1&amp;StartingLineNumber=286&amp;Timestamp=491818311.848353"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9345&amp;EndingColumnNumber=58&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=491666546.943273"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=9327&amp;EndingColumnNumber=58&amp;EndingLineNumber=285&amp;StartingColumnNumber=1&amp;StartingLineNumber=285&amp;Timestamp=491818311.848462"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.943449"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=56&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.848569"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11716&amp;EndingColumnNumber=55&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491666546.943625"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=11698&amp;EndingColumnNumber=55&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=491818311.848675"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=12000&amp;EndingColumnNumber=64&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491666546.943798"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=11982&amp;EndingColumnNumber=64&amp;EndingLineNumber=371&amp;StartingColumnNumber=1&amp;StartingLineNumber=371&amp;Timestamp=491818311.848778"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6823&amp;EndingColumnNumber=55&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491666546.94397"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6814&amp;EndingColumnNumber=55&amp;EndingLineNumber=213&amp;StartingColumnNumber=1&amp;StartingLineNumber=213&amp;Timestamp=491818305.048023"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6650&amp;EndingColumnNumber=55&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=491666546.944146"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6641&amp;EndingColumnNumber=55&amp;EndingLineNumber=207&amp;StartingColumnNumber=1&amp;StartingLineNumber=207&amp;Timestamp=491818305.048146"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=7&amp;CharacterRangeLoc=7020&amp;EndingColumnNumber=31&amp;EndingLineNumber=216&amp;StartingColumnNumber=24&amp;StartingLineNumber=216&amp;Timestamp=491666546.966425"
+         documentLocation = "#CharacterRangeLen=7&amp;CharacterRangeLoc=7011&amp;EndingColumnNumber=31&amp;EndingLineNumber=216&amp;StartingColumnNumber=24&amp;StartingLineNumber=216&amp;Timestamp=491818305.048267"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9523&amp;EndingColumnNumber=49&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491666546.944525"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=9505&amp;EndingColumnNumber=49&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491818311.849185"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -704,269 +704,269 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4372&amp;EndingColumnNumber=54&amp;EndingLineNumber=150&amp;StartingColumnNumber=1&amp;StartingLineNumber=150&amp;Timestamp=491666048.016693"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4363&amp;EndingColumnNumber=54&amp;EndingLineNumber=150&amp;StartingColumnNumber=1&amp;StartingLineNumber=150&amp;Timestamp=491818305.04886"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4170&amp;EndingColumnNumber=48&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=491666048.016817"
+         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4161&amp;EndingColumnNumber=48&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=491818305.04898"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3973&amp;EndingColumnNumber=55&amp;EndingLineNumber=136&amp;StartingColumnNumber=1&amp;StartingLineNumber=136&amp;Timestamp=491666048.016956"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3964&amp;EndingColumnNumber=55&amp;EndingLineNumber=136&amp;StartingColumnNumber=1&amp;StartingLineNumber=136&amp;Timestamp=491818305.049099"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=120&amp;CharacterRangeLoc=3732&amp;EndingColumnNumber=55&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=491666048.017092"
+         documentLocation = "#CharacterRangeLen=120&amp;CharacterRangeLoc=3723&amp;EndingColumnNumber=55&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=491818305.049218"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3541&amp;EndingColumnNumber=64&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=491666048.017229"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3532&amp;EndingColumnNumber=64&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=491818305.049337"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=39&amp;CharacterRangeLoc=4680&amp;EndingColumnNumber=39&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=491666546.946068"
+         documentLocation = "#CharacterRangeLen=39&amp;CharacterRangeLoc=4671&amp;EndingColumnNumber=39&amp;EndingLineNumber=158&amp;StartingColumnNumber=1&amp;StartingLineNumber=158&amp;Timestamp=491818305.049464"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6715&amp;EndingColumnNumber=63&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=248&amp;Timestamp=491666546.946245"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6706&amp;EndingColumnNumber=63&amp;EndingLineNumber=248&amp;StartingColumnNumber=1&amp;StartingLineNumber=248&amp;Timestamp=491818305.049585"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6475&amp;EndingColumnNumber=60&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.94642"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=6466&amp;EndingColumnNumber=60&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.049704"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6282&amp;EndingColumnNumber=61&amp;EndingLineNumber=221&amp;StartingColumnNumber=1&amp;StartingLineNumber=221&amp;Timestamp=491666546.946597"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=6273&amp;EndingColumnNumber=61&amp;EndingLineNumber=221&amp;StartingColumnNumber=1&amp;StartingLineNumber=221&amp;Timestamp=491818305.049825"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=6089&amp;EndingColumnNumber=51&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=491666546.946769"
+         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=6080&amp;EndingColumnNumber=51&amp;EndingLineNumber=217&amp;StartingColumnNumber=1&amp;StartingLineNumber=217&amp;Timestamp=491818305.049943"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5911&amp;EndingColumnNumber=34&amp;EndingLineNumber=204&amp;StartingColumnNumber=21&amp;StartingLineNumber=204&amp;Timestamp=491666546.946966"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=5902&amp;EndingColumnNumber=34&amp;EndingLineNumber=204&amp;StartingColumnNumber=21&amp;StartingLineNumber=204&amp;Timestamp=491818305.050062"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5739&amp;EndingColumnNumber=58&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491666546.947193"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5730&amp;EndingColumnNumber=58&amp;EndingLineNumber=206&amp;StartingColumnNumber=1&amp;StartingLineNumber=206&amp;Timestamp=491818305.05018"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5569&amp;EndingColumnNumber=50&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491666546.947442"
+         documentLocation = "#CharacterRangeLen=49&amp;CharacterRangeLoc=5560&amp;EndingColumnNumber=50&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491818305.050308"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5413&amp;EndingColumnNumber=44&amp;EndingLineNumber=194&amp;StartingColumnNumber=1&amp;StartingLineNumber=194&amp;Timestamp=491666546.947723"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5404&amp;EndingColumnNumber=44&amp;EndingLineNumber=194&amp;StartingColumnNumber=1&amp;StartingLineNumber=194&amp;Timestamp=491818305.050456"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5248&amp;EndingColumnNumber=63&amp;EndingLineNumber=188&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491666546.947968"
+         documentLocation = "#CharacterRangeLen=56&amp;CharacterRangeLoc=5239&amp;EndingColumnNumber=63&amp;EndingLineNumber=188&amp;StartingColumnNumber=1&amp;StartingLineNumber=188&amp;Timestamp=491818305.050581"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=68&amp;CharacterRangeLoc=8896&amp;EndingColumnNumber=55&amp;EndingLineNumber=277&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=491666546.948187"
+         documentLocation = "#CharacterRangeLen=68&amp;CharacterRangeLoc=8878&amp;EndingColumnNumber=55&amp;EndingLineNumber=277&amp;StartingColumnNumber=1&amp;StartingLineNumber=277&amp;Timestamp=491818311.851094"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=234&amp;CharacterRangeLoc=8572&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948406"
+         documentLocation = "#CharacterRangeLen=234&amp;CharacterRangeLoc=8554&amp;EndingColumnNumber=53&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818311.851197"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8572&amp;EndingColumnNumber=54&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948626"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=8554&amp;EndingColumnNumber=54&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818311.8513"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=69&amp;CharacterRangeLoc=8411&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.948852"
+         documentLocation = "#CharacterRangeLen=69&amp;CharacterRangeLoc=8402&amp;EndingColumnNumber=55&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.051055"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7234&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491666546.949076"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=7225&amp;EndingColumnNumber=47&amp;EndingLineNumber=273&amp;StartingColumnNumber=1&amp;StartingLineNumber=272&amp;Timestamp=491818305.051176"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7126&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=491666546.949298"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=7117&amp;EndingColumnNumber=46&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=491818305.051297"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7118&amp;EndingColumnNumber=55&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=250&amp;Timestamp=491666546.949524"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7109&amp;EndingColumnNumber=55&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=250&amp;Timestamp=491818305.051418"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6975&amp;EndingColumnNumber=53&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491666546.949737"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6966&amp;EndingColumnNumber=53&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491818305.051538"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6822&amp;EndingColumnNumber=34&amp;EndingLineNumber=211&amp;StartingColumnNumber=19&amp;StartingLineNumber=211&amp;Timestamp=491666546.949932"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6813&amp;EndingColumnNumber=34&amp;EndingLineNumber=211&amp;StartingColumnNumber=19&amp;StartingLineNumber=211&amp;Timestamp=491818305.051662"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6711&amp;EndingColumnNumber=55&amp;EndingLineNumber=235&amp;StartingColumnNumber=1&amp;StartingLineNumber=235&amp;Timestamp=491666546.950116"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6702&amp;EndingColumnNumber=55&amp;EndingLineNumber=235&amp;StartingColumnNumber=1&amp;StartingLineNumber=235&amp;Timestamp=491818305.051783"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6587&amp;EndingColumnNumber=47&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491666546.950296"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6578&amp;EndingColumnNumber=47&amp;EndingLineNumber=228&amp;StartingColumnNumber=1&amp;StartingLineNumber=228&amp;Timestamp=491818305.051901"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6480&amp;EndingColumnNumber=46&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=491666546.950432"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6471&amp;EndingColumnNumber=46&amp;EndingLineNumber=224&amp;StartingColumnNumber=1&amp;StartingLineNumber=224&amp;Timestamp=491818305.052023"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6070&amp;EndingColumnNumber=63&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=491666546.950544"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6061&amp;EndingColumnNumber=63&amp;EndingLineNumber=209&amp;StartingColumnNumber=1&amp;StartingLineNumber=209&amp;Timestamp=491818305.052143"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5830&amp;EndingColumnNumber=60&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491666546.950649"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=5821&amp;EndingColumnNumber=60&amp;EndingLineNumber=202&amp;StartingColumnNumber=1&amp;StartingLineNumber=202&amp;Timestamp=491818305.052263"
          lockedSize = "{461, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5629&amp;EndingColumnNumber=61&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=491666546.950758"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5620&amp;EndingColumnNumber=61&amp;EndingLineNumber=196&amp;StartingColumnNumber=1&amp;StartingLineNumber=196&amp;Timestamp=491818305.052389"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5435&amp;EndingColumnNumber=51&amp;EndingLineNumber=190&amp;StartingColumnNumber=1&amp;StartingLineNumber=190&amp;Timestamp=491666546.95086"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5426&amp;EndingColumnNumber=51&amp;EndingLineNumber=190&amp;StartingColumnNumber=1&amp;StartingLineNumber=190&amp;Timestamp=491818305.052508"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5257&amp;EndingColumnNumber=58&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=491666546.950964"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5248&amp;EndingColumnNumber=58&amp;EndingLineNumber=184&amp;StartingColumnNumber=1&amp;StartingLineNumber=184&amp;Timestamp=491818305.052661"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5085&amp;EndingColumnNumber=58&amp;EndingLineNumber=178&amp;StartingColumnNumber=1&amp;StartingLineNumber=178&amp;Timestamp=491666546.951066"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5076&amp;EndingColumnNumber=58&amp;EndingLineNumber=178&amp;StartingColumnNumber=1&amp;StartingLineNumber=178&amp;Timestamp=491818305.052782"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4921&amp;EndingColumnNumber=44&amp;EndingLineNumber=172&amp;StartingColumnNumber=1&amp;StartingLineNumber=172&amp;Timestamp=491666546.95117"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=4912&amp;EndingColumnNumber=44&amp;EndingLineNumber=172&amp;StartingColumnNumber=1&amp;StartingLineNumber=172&amp;Timestamp=491818305.052902"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4531&amp;EndingColumnNumber=24&amp;EndingLineNumber=159&amp;StartingColumnNumber=1&amp;StartingLineNumber=159&amp;Timestamp=491666546.951273"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4522&amp;EndingColumnNumber=24&amp;EndingLineNumber=159&amp;StartingColumnNumber=1&amp;StartingLineNumber=159&amp;Timestamp=491818305.053022"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7117&amp;EndingColumnNumber=55&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=491666546.951381"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=7108&amp;EndingColumnNumber=55&amp;EndingLineNumber=244&amp;StartingColumnNumber=1&amp;StartingLineNumber=244&amp;Timestamp=491818305.053144"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6974&amp;EndingColumnNumber=53&amp;EndingLineNumber=239&amp;StartingColumnNumber=1&amp;StartingLineNumber=239&amp;Timestamp=491666546.951484"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6965&amp;EndingColumnNumber=53&amp;EndingLineNumber=239&amp;StartingColumnNumber=1&amp;StartingLineNumber=239&amp;Timestamp=491818305.053263"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6821&amp;EndingColumnNumber=54&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=491666546.951587"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6812&amp;EndingColumnNumber=54&amp;EndingLineNumber=233&amp;StartingColumnNumber=1&amp;StartingLineNumber=233&amp;Timestamp=491818305.053381"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6710&amp;EndingColumnNumber=55&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491666546.951765"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6701&amp;EndingColumnNumber=55&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491818305.053499"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6586&amp;EndingColumnNumber=47&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.951947"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6577&amp;EndingColumnNumber=47&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.053618"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6479&amp;EndingColumnNumber=55&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=491666546.952128"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=6470&amp;EndingColumnNumber=55&amp;EndingLineNumber=223&amp;StartingColumnNumber=1&amp;StartingLineNumber=223&amp;Timestamp=491818305.053744"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6069&amp;EndingColumnNumber=63&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491666546.952308"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=6060&amp;EndingColumnNumber=63&amp;EndingLineNumber=208&amp;StartingColumnNumber=1&amp;StartingLineNumber=208&amp;Timestamp=491818305.053857"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5828&amp;EndingColumnNumber=61&amp;EndingLineNumber=201&amp;StartingColumnNumber=1&amp;StartingLineNumber=201&amp;Timestamp=491666546.952488"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5819&amp;EndingColumnNumber=61&amp;EndingLineNumber=201&amp;StartingColumnNumber=1&amp;StartingLineNumber=201&amp;Timestamp=491818305.053968"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5634&amp;EndingColumnNumber=51&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=491666546.952669"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5625&amp;EndingColumnNumber=51&amp;EndingLineNumber=195&amp;StartingColumnNumber=1&amp;StartingLineNumber=195&amp;Timestamp=491818305.054079"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5456&amp;EndingColumnNumber=58&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=189&amp;Timestamp=491666546.952853"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5447&amp;EndingColumnNumber=58&amp;EndingLineNumber=189&amp;StartingColumnNumber=1&amp;StartingLineNumber=189&amp;Timestamp=491818305.054192"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5284&amp;EndingColumnNumber=58&amp;EndingLineNumber=183&amp;StartingColumnNumber=1&amp;StartingLineNumber=183&amp;Timestamp=491666546.952967"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5275&amp;EndingColumnNumber=58&amp;EndingLineNumber=183&amp;StartingColumnNumber=1&amp;StartingLineNumber=183&amp;Timestamp=491818305.054303"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5120&amp;EndingColumnNumber=44&amp;EndingLineNumber=177&amp;StartingColumnNumber=1&amp;StartingLineNumber=177&amp;Timestamp=491666546.953073"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5111&amp;EndingColumnNumber=44&amp;EndingLineNumber=177&amp;StartingColumnNumber=1&amp;StartingLineNumber=177&amp;Timestamp=491818305.054415"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4732&amp;EndingColumnNumber=24&amp;EndingLineNumber=165&amp;StartingColumnNumber=1&amp;StartingLineNumber=165&amp;Timestamp=491666546.953179"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4723&amp;EndingColumnNumber=24&amp;EndingLineNumber=165&amp;StartingColumnNumber=1&amp;StartingLineNumber=165&amp;Timestamp=491818305.054523"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4539&amp;EndingColumnNumber=60&amp;EndingLineNumber=156&amp;StartingColumnNumber=1&amp;StartingLineNumber=156&amp;Timestamp=491666546.953282"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4530&amp;EndingColumnNumber=60&amp;EndingLineNumber=156&amp;StartingColumnNumber=1&amp;StartingLineNumber=156&amp;Timestamp=491818305.054633"
          lockedSize = "{426, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4345&amp;EndingColumnNumber=54&amp;EndingLineNumber=148&amp;StartingColumnNumber=1&amp;StartingLineNumber=148&amp;Timestamp=491666048.022888"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4336&amp;EndingColumnNumber=54&amp;EndingLineNumber=148&amp;StartingColumnNumber=1&amp;StartingLineNumber=148&amp;Timestamp=491818305.054747"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3945&amp;EndingColumnNumber=55&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=491666048.023001"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3936&amp;EndingColumnNumber=55&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=491818305.054857"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3704&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491666048.023112"
+         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3695&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491818305.054967"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3513&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491666048.023226"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3504&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491818305.055077"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -976,73 +976,73 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6723&amp;EndingColumnNumber=53&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491666546.953906"
+         documentLocation = "#CharacterRangeLen=52&amp;CharacterRangeLoc=6714&amp;EndingColumnNumber=53&amp;EndingLineNumber=231&amp;StartingColumnNumber=1&amp;StartingLineNumber=231&amp;Timestamp=491818305.055297"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6592&amp;EndingColumnNumber=54&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491666546.95401"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=6583&amp;EndingColumnNumber=54&amp;EndingLineNumber=227&amp;StartingColumnNumber=1&amp;StartingLineNumber=227&amp;Timestamp=491818305.055408"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6355&amp;EndingColumnNumber=47&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491666546.954112"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=6346&amp;EndingColumnNumber=47&amp;EndingLineNumber=219&amp;StartingColumnNumber=1&amp;StartingLineNumber=219&amp;Timestamp=491818305.055518"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6248&amp;EndingColumnNumber=46&amp;EndingLineNumber=215&amp;StartingColumnNumber=1&amp;StartingLineNumber=215&amp;Timestamp=491666546.954214"
+         documentLocation = "#CharacterRangeLen=45&amp;CharacterRangeLoc=6239&amp;EndingColumnNumber=46&amp;EndingLineNumber=215&amp;StartingColumnNumber=1&amp;StartingLineNumber=215&amp;Timestamp=491818305.055628"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5838&amp;EndingColumnNumber=63&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491666546.954318"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=5829&amp;EndingColumnNumber=63&amp;EndingLineNumber=200&amp;StartingColumnNumber=1&amp;StartingLineNumber=200&amp;Timestamp=491818305.055739"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5597&amp;EndingColumnNumber=61&amp;EndingLineNumber=193&amp;StartingColumnNumber=1&amp;StartingLineNumber=193&amp;Timestamp=491666546.954422"
+         documentLocation = "#CharacterRangeLen=60&amp;CharacterRangeLoc=5588&amp;EndingColumnNumber=61&amp;EndingLineNumber=193&amp;StartingColumnNumber=1&amp;StartingLineNumber=193&amp;Timestamp=491818305.05585"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5403&amp;EndingColumnNumber=51&amp;EndingLineNumber=187&amp;StartingColumnNumber=1&amp;StartingLineNumber=187&amp;Timestamp=491666546.954526"
+         documentLocation = "#CharacterRangeLen=50&amp;CharacterRangeLoc=5394&amp;EndingColumnNumber=51&amp;EndingLineNumber=187&amp;StartingColumnNumber=1&amp;StartingLineNumber=187&amp;Timestamp=491818305.05596"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5225&amp;EndingColumnNumber=58&amp;EndingLineNumber=181&amp;StartingColumnNumber=1&amp;StartingLineNumber=181&amp;Timestamp=491666546.954627"
+         documentLocation = "#CharacterRangeLen=57&amp;CharacterRangeLoc=5216&amp;EndingColumnNumber=58&amp;EndingLineNumber=181&amp;StartingColumnNumber=1&amp;StartingLineNumber=181&amp;Timestamp=491818305.056072"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5067&amp;EndingColumnNumber=44&amp;EndingLineNumber=175&amp;StartingColumnNumber=1&amp;StartingLineNumber=175&amp;Timestamp=491666546.954729"
+         documentLocation = "#CharacterRangeLen=43&amp;CharacterRangeLoc=5058&amp;EndingColumnNumber=44&amp;EndingLineNumber=175&amp;StartingColumnNumber=1&amp;StartingLineNumber=175&amp;Timestamp=491818305.056186"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4678&amp;EndingColumnNumber=24&amp;EndingLineNumber=163&amp;StartingColumnNumber=1&amp;StartingLineNumber=162&amp;Timestamp=491666546.954833"
+         documentLocation = "#CharacterRangeLen=23&amp;CharacterRangeLoc=4669&amp;EndingColumnNumber=24&amp;EndingLineNumber=163&amp;StartingColumnNumber=1&amp;StartingLineNumber=162&amp;Timestamp=491818305.056298"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4486&amp;EndingColumnNumber=60&amp;EndingLineNumber=153&amp;StartingColumnNumber=1&amp;StartingLineNumber=152&amp;Timestamp=491666540.521503"
+         documentLocation = "#CharacterRangeLen=59&amp;CharacterRangeLoc=4477&amp;EndingColumnNumber=60&amp;EndingLineNumber=153&amp;StartingColumnNumber=1&amp;StartingLineNumber=152&amp;Timestamp=491818305.05641"
          lockedSize = "{458, 70}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3892&amp;EndingColumnNumber=55&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=491666048.024683"
+         documentLocation = "#CharacterRangeLen=54&amp;CharacterRangeLoc=3883&amp;EndingColumnNumber=55&amp;EndingLineNumber=132&amp;StartingColumnNumber=1&amp;StartingLineNumber=132&amp;Timestamp=491818305.056525"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3716&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491666048.0248"
+         documentLocation = "#CharacterRangeLen=55&amp;CharacterRangeLoc=3707&amp;EndingColumnNumber=56&amp;EndingLineNumber=125&amp;StartingColumnNumber=1&amp;StartingLineNumber=125&amp;Timestamp=491818305.056638"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3525&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491666048.024913"
+         documentLocation = "#CharacterRangeLen=63&amp;CharacterRangeLoc=3516&amp;EndingColumnNumber=64&amp;EndingLineNumber=118&amp;StartingColumnNumber=1&amp;StartingLineNumber=118&amp;Timestamp=491818305.056747"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -1052,12 +1052,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4292&amp;EndingColumnNumber=54&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=491666048.025139"
+         documentLocation = "#CharacterRangeLen=53&amp;CharacterRangeLoc=4283&amp;EndingColumnNumber=54&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=491818305.056963"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4089&amp;EndingColumnNumber=48&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491666048.025251"
+         documentLocation = "#CharacterRangeLen=47&amp;CharacterRangeLoc=4080&amp;EndingColumnNumber=48&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491818305.057075"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
+++ b/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
@@ -1,7 +1,7 @@
 /*: 
 ## Threatening Monad
 
-Previous installments have focussed on **nil**, **NilLiteralConvertible**, **Optionals** and custom **Maybe** types.
+Previous installments have focussed on **nil**, **ExpressibleByNilLiteral**, **Optionals** and custom **Maybe** types.
 This time let's step away from the tentative world of **Optionals** and take a look at a different beast.
 
 The **Threat** monad!
@@ -22,11 +22,11 @@ enum ThreatLevel : Int, CustomStringConvertible {
     
     var description: String {
         switch self {
-        case low :      return "Low"
-        case guarded :  return "Guarded"
-        case elevated : return "Elevated"
-        case high :     return "High"
-        case severe :   return "Severe"
+        case .low :      return "Low"
+        case .guarded :  return "Guarded"
+        case .elevated : return "Elevated"
+        case .high :     return "High"
+        case .severe :   return "Severe"
         }
     }
 }

--- a/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
+++ b/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
@@ -106,8 +106,12 @@ Both the first parameter **Threat<A>** and the return type of the function param
 **ThreatLevel** property. The only logic that needs to be implemented is to ensure that the
 highest **ThreatLevel** is attached to the return value of the bind function.
 */
-infix operator >>= {associativity left}
-func >>= <A,B> (t: Threat<A>, f: @noescape (A) -> Threat<B>) -> Threat<B> {
+precedencegroup BindPrecedence {
+	associativity: left
+	higherThan: AssignmentPrecedence
+}
+infix operator >>= : BindPrecedence
+func >>= <A,B> (t: Threat<A>, f: (A) -> Threat<B>) -> Threat<B> {
     let t2 = f(t.value) // apply function f – the type of t2 is Threat<B>
     
     // return a new Threat with the value from t2
@@ -372,7 +376,7 @@ If we were using Haskell, this function would be available to use for any monadi
 Unfortunately it is not (yet) possible to inform Swift's type system that a particular type is monadic,
 which means that we need to manually create the following function for every monadic type : (
 */
-func liftM<A,B>(_ m1: Threat<A>, _ m2: Threat<A>, f: @noescape (A,A) -> B) -> Threat<B> {
+func liftM<A,B>(_ m1: Threat<A>, _ m2: Threat<A>, f: (A,A) -> B) -> Threat<B> {
     return m1 >>= { x in m2 >>= { pure(f(x, $0)) } }
 }
 /*:

--- a/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
+++ b/Playgrounds/6a_Threatening_Monad.playground/Contents.swift
@@ -18,15 +18,15 @@ An **enum** that represents the various threat levels.
 It has an **Int** rawValue to make it easy to implement the **Comparable** protocol.
 */
 enum ThreatLevel : Int, CustomStringConvertible {
-    case Low = 0, Guarded, Elevated, High, Severe
+    case low = 0, guarded, elevated, high, severe
     
     var description: String {
         switch self {
-        case Low :      return "Low"
-        case Guarded :  return "Guarded"
-        case Elevated : return "Elevated"
-        case High :     return "High"
-        case Severe :   return "Severe"
+        case low :      return "Low"
+        case guarded :  return "Guarded"
+        case elevated : return "Elevated"
+        case high :     return "High"
+        case severe :   return "Severe"
         }
     }
 }
@@ -68,12 +68,12 @@ struct Threat<T> : CustomStringConvertible {
     }
 }
 //: **map** - makes it possible to apply functions to the value inside the **Threat** struct
-func map<A,B>(x: Threat<A>, f: A -> B) -> Threat<B> {
+func map<A,B>(_ x: Threat<A>, f: (A) -> B) -> Threat<B> {
     return Threat(x.threat, f(x.value))
 }
 //: **Monadic 'return'** - default level is **Low**
-func pure<T>(x: T) -> Threat<T> {
-    return Threat(.Low, x)
+func pure<T>(_ x: T) -> Threat<T> {
+    return Threat(.low, x)
 }
 /*:
 ### **Bind operator for Threat struct**
@@ -107,7 +107,7 @@ Both the first parameter **Threat<A>** and the return type of the function param
 highest **ThreatLevel** is attached to the return value of the bind function.
 */
 infix operator >>= {associativity left}
-func >>= <A,B> (t: Threat<A>, @noescape f: A -> Threat<B>) -> Threat<B> {
+func >>= <A,B> (t: Threat<A>, f: @noescape (A) -> Threat<B>) -> Threat<B> {
     let t2 = f(t.value) // apply function f – the type of t2 is Threat<B>
     
     // return a new Threat with the value from t2
@@ -117,7 +117,7 @@ func >>= <A,B> (t: Threat<A>, @noescape f: A -> Threat<B>) -> Threat<B> {
 /*:
 **A simple example of Threat struct** – Make a dangerous number
 */
-let n = Threat(.High, 666)
+let n = Threat(.high, 666)
 print(n)
 
 //:**Apply a function to the dangerous number** – the **ThreatLevel** is preserved
@@ -148,7 +148,7 @@ struct Person : CustomStringConvertible {
     let occupation: String
     let threat: ThreatLevel
     
-    init(name: String, occupation: String, threat: ThreatLevel = .Low) {
+    init(name: String, occupation: String, threat: ThreatLevel = .low) {
         self.name = name
         self.occupation = occupation
         self.threat = threat
@@ -193,8 +193,10 @@ A **Threat<[Person]>** struct needs to be intialized with two parameters, a **Th
 The first parameter is taken directly from the supplied **Person** by accessing their **threat** property 
 and the second parameter is the result of adding the **Person** to the supplied **Array**.
 */
-func addPerson(person: Person)(_ list: [Person]) -> Threat<[Person]> {
-    return Threat(person.threat, list + [person])
+func addPerson(_ person: Person) -> ([Person]) -> Threat<[Person]> {
+	return { list in
+		return Threat(person.threat, list + [person])
+	}
 }
 /*:
 The only unusual thing about the above function is that it is defined to be explicitly **curried**.
@@ -233,7 +235,7 @@ Quite simply call the function with the first parameter (**Person**),
 (the return value will be a new function expecting an **Array**). Pass an empty **Array**.
 The return value of the expression will be **Threat<[Person]>**.
 */
-let mediumRisk = addPerson(Person(name: "Bob", occupation: "Wrestler", threat: .Elevated))([])
+let mediumRisk = addPerson(Person(name: "Bob", occupation: "Wrestler", threat: .elevated))([])
 print(mediumRisk)
 
 /*:
@@ -248,7 +250,7 @@ and passing it as the second argument to the **addPerson** function.
 
 This time we'll add a less dangerous **Person** to the list, an Artist with a **Low ThreatLevel**.
 */
-let mellow = addPerson(Person(name: "Jeff", occupation: "Artist", threat: .Low))(mediumRisk.value)
+let mellow = addPerson(Person(name: "Jeff", occupation: "Artist", threat: .low))(mediumRisk.value)
 print(mellow)
 
 /*:
@@ -265,7 +267,7 @@ is preserved when returning the new value.
 
 #### **Adding a *Person* to a pre-populated list – *the correct way***
 */
-let correct = mediumRisk >>= addPerson(Person(name: "Jeff", occupation: "Artist", threat: .Low))
+let correct = mediumRisk >>= addPerson(Person(name: "Jeff", occupation: "Artist", threat: .low))
 print(correct)
 
 /*:
@@ -301,7 +303,7 @@ print(safeGroup)
 /*:
 Now let's add a dubious character to the safeGroup to see what the result is:
 */
-let dodgy = safeGroup >>= addPerson(Person(name: "Gideon", occupation: "MP", threat: .Elevated))
+let dodgy = safeGroup >>= addPerson(Person(name: "Gideon", occupation: "MP", threat: .elevated))
 print(dodgy)
 
 /*:
@@ -314,10 +316,10 @@ Below, we create a mixed group of people with varying **ThreatLevels**,
 the **ThreatLevel** of the entire group matches the highest **ThreatLevel** of the individual people – 
 it doesn't matter what order the people are added to the group.
 */
-let dangerGroup = addPerson(Person(name: "Jean", occupation: "Thief", threat: .Guarded))([])
-              >>= addPerson(Person(name: "Lucy", occupation: "Juggler", threat: .Severe))
-              >>= addPerson(Person(name: "Beth", occupation: "PsychoKiller", threat: .High))
-              >>= addPerson(Person(name: "Ada", occupation: "Programmer")) // threat: .Low
+let dangerGroup = addPerson(Person(name: "Jean", occupation: "Thief", threat: .guarded))([])
+              >>= addPerson(Person(name: "Lucy", occupation: "Juggler", threat: .severe))
+              >>= addPerson(Person(name: "Beth", occupation: "PsychoKiller", threat: .high))
+              >>= addPerson(Person(name: "Ada", occupation: "Programmer")) // threat: .low
 
 print(dangerGroup)
 
@@ -370,7 +372,7 @@ If we were using Haskell, this function would be available to use for any monadi
 Unfortunately it is not (yet) possible to inform Swift's type system that a particular type is monadic,
 which means that we need to manually create the following function for every monadic type : (
 */
-func liftM<A,B>(m1: Threat<A>, _ m2: Threat<A>, @noescape f: (A,A) -> B) -> Threat<B> {
+func liftM<A,B>(_ m1: Threat<A>, _ m2: Threat<A>, f: @noescape (A,A) -> B) -> Threat<B> {
     return m1 >>= { x in m2 >>= { pure(f(x, $0)) } }
 }
 /*:

--- a/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
+++ b/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
@@ -3,58 +3,58 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=673&amp;EndingColumnNumber=11&amp;EndingLineNumber=363&amp;StartingColumnNumber=1&amp;StartingLineNumber=363&amp;Timestamp=472918719.45784"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=673&amp;EndingColumnNumber=11&amp;EndingLineNumber=365&amp;StartingColumnNumber=1&amp;StartingLineNumber=365&amp;Timestamp=491666649.529754"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15618&amp;EndingColumnNumber=12&amp;EndingLineNumber=352&amp;StartingColumnNumber=1&amp;StartingLineNumber=352&amp;Timestamp=472918719.458205"
+         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15633&amp;EndingColumnNumber=12&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491666649.529904"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14694&amp;EndingColumnNumber=11&amp;EndingLineNumber=336&amp;StartingColumnNumber=1&amp;StartingLineNumber=336&amp;Timestamp=472918719.458513"
+         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14709&amp;EndingColumnNumber=11&amp;EndingLineNumber=338&amp;StartingColumnNumber=1&amp;StartingLineNumber=338&amp;Timestamp=491666649.530022"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17135&amp;EndingColumnNumber=13&amp;EndingLineNumber=378&amp;StartingColumnNumber=1&amp;StartingLineNumber=378&amp;Timestamp=472918719.45882"
+         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17150&amp;EndingColumnNumber=13&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491666649.530133"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17484&amp;EndingColumnNumber=11&amp;EndingLineNumber=390&amp;StartingColumnNumber=1&amp;StartingLineNumber=390&amp;Timestamp=472918719.459124"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17499&amp;EndingColumnNumber=11&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491666649.53024"
          lockedSize = "{769, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17484&amp;EndingColumnNumber=12&amp;EndingLineNumber=390&amp;StartingColumnNumber=1&amp;StartingLineNumber=390&amp;Timestamp=472918719.459439"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17499&amp;EndingColumnNumber=12&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491666649.530353"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14152&amp;EndingColumnNumber=14&amp;EndingLineNumber=321&amp;StartingColumnNumber=1&amp;StartingLineNumber=321&amp;Timestamp=472918719.459737"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14167&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491666649.530459"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14259&amp;EndingColumnNumber=15&amp;EndingLineNumber=324&amp;StartingColumnNumber=1&amp;StartingLineNumber=324&amp;Timestamp=472918719.460042"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14274&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491666649.530565"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10695&amp;EndingColumnNumber=11&amp;EndingLineNumber=243&amp;StartingColumnNumber=1&amp;StartingLineNumber=243&amp;Timestamp=472918719.46035"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10710&amp;EndingColumnNumber=11&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491666649.530672"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11259&amp;EndingColumnNumber=16&amp;EndingLineNumber=258&amp;StartingColumnNumber=1&amp;StartingLineNumber=258&amp;Timestamp=472918719.460656"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11274&amp;EndingColumnNumber=16&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491666649.530777"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13809&amp;EndingColumnNumber=17&amp;EndingLineNumber=289&amp;StartingColumnNumber=1&amp;StartingLineNumber=289&amp;Timestamp=472918719.46099"
+         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13824&amp;EndingColumnNumber=17&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491666649.53088"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -99,27 +99,27 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14146&amp;EndingColumnNumber=14&amp;EndingLineNumber=321&amp;StartingColumnNumber=1&amp;StartingLineNumber=321&amp;Timestamp=472918719.464324"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14161&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491666649.531887"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14253&amp;EndingColumnNumber=15&amp;EndingLineNumber=324&amp;StartingColumnNumber=1&amp;StartingLineNumber=324&amp;Timestamp=472918719.464653"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14268&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491666649.531998"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14688&amp;EndingColumnNumber=22&amp;EndingLineNumber=335&amp;StartingColumnNumber=1&amp;StartingLineNumber=335&amp;Timestamp=472918719.464967"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14703&amp;EndingColumnNumber=22&amp;EndingLineNumber=337&amp;StartingColumnNumber=1&amp;StartingLineNumber=337&amp;Timestamp=491666649.532102"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15612&amp;EndingColumnNumber=16&amp;EndingLineNumber=352&amp;StartingColumnNumber=1&amp;StartingLineNumber=352&amp;Timestamp=472918719.46528"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15627&amp;EndingColumnNumber=16&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491666649.532205"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17129&amp;EndingColumnNumber=16&amp;EndingLineNumber=378&amp;StartingColumnNumber=1&amp;StartingLineNumber=378&amp;Timestamp=472918719.465591"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17144&amp;EndingColumnNumber=16&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491666649.532309"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -174,7 +174,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10692&amp;EndingColumnNumber=20&amp;EndingLineNumber=249&amp;StartingColumnNumber=1&amp;StartingLineNumber=249&amp;Timestamp=472918719.469192"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10707&amp;EndingColumnNumber=20&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=251&amp;Timestamp=491666649.533343"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -199,7 +199,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14687&amp;EndingColumnNumber=16&amp;EndingLineNumber=334&amp;StartingColumnNumber=1&amp;StartingLineNumber=334&amp;Timestamp=472918719.471195"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14702&amp;EndingColumnNumber=16&amp;EndingLineNumber=336&amp;StartingColumnNumber=1&amp;StartingLineNumber=336&amp;Timestamp=491666649.534135"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
+++ b/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
@@ -8,453 +8,453 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15633&amp;EndingColumnNumber=12&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491666649.529904"
+         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15638&amp;EndingColumnNumber=12&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491818208.708522"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14709&amp;EndingColumnNumber=11&amp;EndingLineNumber=338&amp;StartingColumnNumber=1&amp;StartingLineNumber=338&amp;Timestamp=491666649.530022"
+         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14714&amp;EndingColumnNumber=11&amp;EndingLineNumber=338&amp;StartingColumnNumber=1&amp;StartingLineNumber=338&amp;Timestamp=491818208.708658"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17150&amp;EndingColumnNumber=13&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491666649.530133"
+         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17155&amp;EndingColumnNumber=13&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491818208.708788"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17499&amp;EndingColumnNumber=11&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491666649.53024"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17504&amp;EndingColumnNumber=11&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491818208.708918"
          lockedSize = "{769, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17499&amp;EndingColumnNumber=12&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491666649.530353"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17504&amp;EndingColumnNumber=12&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491818208.709053"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14167&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491666649.530459"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14172&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491818208.70918"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14274&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491666649.530565"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14279&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491818208.709307"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10710&amp;EndingColumnNumber=11&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491666649.530672"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10715&amp;EndingColumnNumber=11&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491818208.709433"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11274&amp;EndingColumnNumber=16&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491666649.530777"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11279&amp;EndingColumnNumber=16&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491818208.709558"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13824&amp;EndingColumnNumber=17&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491666649.53088"
+         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13829&amp;EndingColumnNumber=17&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491818208.709681"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5323&amp;EndingColumnNumber=6&amp;EndingLineNumber=130&amp;StartingColumnNumber=5&amp;StartingLineNumber=130&amp;Timestamp=472918719.461313"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5328&amp;EndingColumnNumber=6&amp;EndingLineNumber=130&amp;StartingColumnNumber=5&amp;StartingLineNumber=130&amp;Timestamp=491818208.709807"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6545&amp;EndingColumnNumber=16&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=472918719.461615"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6550&amp;EndingColumnNumber=16&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=491818208.709932"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=6658&amp;EndingColumnNumber=17&amp;EndingLineNumber=145&amp;StartingColumnNumber=1&amp;StartingLineNumber=145&amp;Timestamp=472918719.462421"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=6663&amp;EndingColumnNumber=17&amp;EndingLineNumber=145&amp;StartingColumnNumber=1&amp;StartingLineNumber=145&amp;Timestamp=491818208.710057"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=5436&amp;EndingColumnNumber=11&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=472918719.462746"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=5441&amp;EndingColumnNumber=11&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=491818208.710178"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=5558&amp;EndingColumnNumber=12&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=472918719.463049"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=5563&amp;EndingColumnNumber=12&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=491818208.710299"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1169&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=472918719.463362"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1174&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=491818208.710421"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1407&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=472918719.463694"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1412&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=491818208.710548"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2133&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=472918719.46401"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2138&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=491818208.71067"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14161&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491666649.531887"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14166&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491818208.710793"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14268&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491666649.531998"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14273&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491818208.710915"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14703&amp;EndingColumnNumber=22&amp;EndingLineNumber=337&amp;StartingColumnNumber=1&amp;StartingLineNumber=337&amp;Timestamp=491666649.532102"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14708&amp;EndingColumnNumber=22&amp;EndingLineNumber=337&amp;StartingColumnNumber=1&amp;StartingLineNumber=337&amp;Timestamp=491818208.71105"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15627&amp;EndingColumnNumber=16&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491666649.532205"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15632&amp;EndingColumnNumber=16&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491818208.711172"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17144&amp;EndingColumnNumber=16&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491666649.532309"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17149&amp;EndingColumnNumber=16&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491818208.711294"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2372&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472918719.465908"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2377&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=491818208.711418"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2622&amp;EndingColumnNumber=14&amp;EndingLineNumber=82&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=472918719.46625"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2627&amp;EndingColumnNumber=14&amp;EndingLineNumber=82&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=491818208.711539"
          lockedSize = "{619, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2739&amp;EndingColumnNumber=15&amp;EndingLineNumber=119&amp;StartingColumnNumber=1&amp;StartingLineNumber=119&amp;Timestamp=472918719.466589"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2744&amp;EndingColumnNumber=15&amp;EndingLineNumber=119&amp;StartingColumnNumber=1&amp;StartingLineNumber=119&amp;Timestamp=491818208.711669"
          lockedSize = "{620, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5100&amp;EndingColumnNumber=16&amp;EndingLineNumber=130&amp;StartingColumnNumber=1&amp;StartingLineNumber=130&amp;Timestamp=472918719.466918"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5105&amp;EndingColumnNumber=16&amp;EndingLineNumber=130&amp;StartingColumnNumber=1&amp;StartingLineNumber=130&amp;Timestamp=491818208.711797"
          lockedSize = "{621, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5177&amp;EndingColumnNumber=16&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=472918719.467259"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5182&amp;EndingColumnNumber=16&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=491818208.711924"
          lockedSize = "{898, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5424&amp;EndingColumnNumber=16&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=472918719.467583"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5429&amp;EndingColumnNumber=16&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491818208.71205"
          lockedSize = "{899, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=3136&amp;EndingColumnNumber=10&amp;EndingLineNumber=84&amp;StartingColumnNumber=5&amp;StartingLineNumber=84&amp;Timestamp=472918719.467904"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=3141&amp;EndingColumnNumber=10&amp;EndingLineNumber=84&amp;StartingColumnNumber=5&amp;StartingLineNumber=84&amp;Timestamp=491818208.712176"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3765&amp;EndingColumnNumber=16&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=472918719.468553"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3770&amp;EndingColumnNumber=16&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=491818208.712298"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3965&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=472918719.468878"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3970&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=491818208.712419"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10707&amp;EndingColumnNumber=20&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=251&amp;Timestamp=491666649.533343"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10712&amp;EndingColumnNumber=20&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=251&amp;Timestamp=491818208.712541"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3758&amp;EndingColumnNumber=16&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=472918719.4699"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3763&amp;EndingColumnNumber=16&amp;EndingLineNumber=107&amp;StartingColumnNumber=1&amp;StartingLineNumber=107&amp;Timestamp=491818208.712663"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=36&amp;CharacterRangeLoc=3129&amp;EndingColumnNumber=78&amp;EndingLineNumber=96&amp;StartingColumnNumber=42&amp;StartingLineNumber=96&amp;Timestamp=472918719.470238"
+         documentLocation = "#CharacterRangeLen=36&amp;CharacterRangeLoc=3134&amp;EndingColumnNumber=78&amp;EndingLineNumber=96&amp;StartingColumnNumber=42&amp;StartingLineNumber=96&amp;Timestamp=491818208.712785"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3958&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=472918719.470552"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3963&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=491818208.712905"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3680&amp;EndingColumnNumber=16&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=472918719.470865"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3685&amp;EndingColumnNumber=16&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=491818208.713028"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14702&amp;EndingColumnNumber=16&amp;EndingLineNumber=336&amp;StartingColumnNumber=1&amp;StartingLineNumber=336&amp;Timestamp=491666649.534135"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14707&amp;EndingColumnNumber=16&amp;EndingLineNumber=336&amp;StartingColumnNumber=1&amp;StartingLineNumber=336&amp;Timestamp=491818208.713153"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3533&amp;EndingColumnNumber=22&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=472918719.471512"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3538&amp;EndingColumnNumber=22&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=491818208.713275"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3324&amp;EndingColumnNumber=22&amp;EndingLineNumber=98&amp;StartingColumnNumber=1&amp;StartingLineNumber=98&amp;Timestamp=472918719.471828"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3329&amp;EndingColumnNumber=22&amp;EndingLineNumber=98&amp;StartingColumnNumber=1&amp;StartingLineNumber=98&amp;Timestamp=491818208.713398"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3216&amp;EndingColumnNumber=22&amp;EndingLineNumber=95&amp;StartingColumnNumber=1&amp;StartingLineNumber=95&amp;Timestamp=472918719.472144"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3221&amp;EndingColumnNumber=22&amp;EndingLineNumber=95&amp;StartingColumnNumber=1&amp;StartingLineNumber=95&amp;Timestamp=491818208.71352"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2130&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=472918719.472457"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2135&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=491818208.713641"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2250&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472918719.472775"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2255&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=491818208.713779"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2608&amp;EndingColumnNumber=19&amp;EndingLineNumber=82&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=472918719.473092"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2613&amp;EndingColumnNumber=19&amp;EndingLineNumber=82&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=491818208.713892"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2725&amp;EndingColumnNumber=15&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=472918719.473423"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2730&amp;EndingColumnNumber=15&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=491818208.714125"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=3109&amp;EndingColumnNumber=21&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=472918719.473735"
+         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=3114&amp;EndingColumnNumber=21&amp;EndingLineNumber=92&amp;StartingColumnNumber=1&amp;StartingLineNumber=92&amp;Timestamp=491818208.714304"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3196&amp;EndingColumnNumber=22&amp;EndingLineNumber=95&amp;StartingColumnNumber=1&amp;StartingLineNumber=95&amp;Timestamp=472918719.474051"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3201&amp;EndingColumnNumber=22&amp;EndingLineNumber=95&amp;StartingColumnNumber=1&amp;StartingLineNumber=95&amp;Timestamp=491818208.714422"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=25&amp;CharacterRangeLoc=3304&amp;EndingColumnNumber=51&amp;EndingLineNumber=100&amp;StartingColumnNumber=26&amp;StartingLineNumber=100&amp;Timestamp=472918719.474366"
+         documentLocation = "#CharacterRangeLen=25&amp;CharacterRangeLoc=3309&amp;EndingColumnNumber=51&amp;EndingLineNumber=100&amp;StartingColumnNumber=26&amp;StartingLineNumber=100&amp;Timestamp=491818208.714535"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3513&amp;EndingColumnNumber=22&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=472918719.474691"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3518&amp;EndingColumnNumber=22&amp;EndingLineNumber=104&amp;StartingColumnNumber=1&amp;StartingLineNumber=104&amp;Timestamp=491818208.714698"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2724&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=472918719.475009"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2729&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=491818208.714831"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=3108&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=472918719.475325"
+         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=3113&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491818208.715029"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3195&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=472918719.475639"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3200&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491818208.715231"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3303&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=472918719.475952"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3308&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491818208.715373"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3512&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=472918719.476266"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3517&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=491818208.715551"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2364&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472918719.476584"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2369&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=491818208.715717"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2607&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=472918719.4769"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2612&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=491818208.71584"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2479&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=472918719.477239"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2484&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=491818208.715957"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2596&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=472918719.477555"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2601&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=491818208.716072"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2236&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472918719.477871"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2241&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=491818208.716188"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1262&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=472918719.478386"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1267&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=491818208.716301"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1301&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=472918719.478715"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1306&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=491818208.716416"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2002&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=472918719.47903"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2007&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=491818208.716532"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2122&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472918719.479361"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2127&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=491818208.716646"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=2980&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=472918719.479675"
+         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=2985&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491818208.716758"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3067&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=472918719.480051"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3072&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491818208.716873"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3170&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=472918719.48039"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3175&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491818208.716985"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3388&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=472918719.48071"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3393&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=491818208.717098"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=17&amp;CharacterRangeLoc=3405&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=472918719.481029"
+         documentLocation = "#CharacterRangeLen=17&amp;CharacterRangeLoc=3410&amp;EndingColumnNumber=22&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=491818208.717214"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3187&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=472918719.481346"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3192&amp;EndingColumnNumber=22&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491818208.717327"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3084&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=472918719.481661"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=3089&amp;EndingColumnNumber=22&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491818208.717441"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=2997&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=472918719.481977"
+         documentLocation = "#CharacterRangeLen=20&amp;CharacterRangeLoc=3002&amp;EndingColumnNumber=21&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491818208.717556"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2613&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=472918719.482296"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2618&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=491818208.717671"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2496&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=472918719.482614"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=2501&amp;EndingColumnNumber=19&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=491818208.717786"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2253&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472918719.482937"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2258&amp;EndingColumnNumber=17&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=491818208.717916"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2139&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472918719.483256"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2144&amp;EndingColumnNumber=16&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=491818208.71802"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2019&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=472918719.483576"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=2024&amp;EndingColumnNumber=20&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=491818208.718127"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1318&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=472918719.483894"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1323&amp;EndingColumnNumber=12&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=491818208.71823"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1279&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=472918719.484205"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=1284&amp;EndingColumnNumber=11&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=491818208.718332"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3440&amp;EndingColumnNumber=20&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=472918719.484519"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3445&amp;EndingColumnNumber=20&amp;EndingLineNumber=103&amp;StartingColumnNumber=1&amp;StartingLineNumber=103&amp;Timestamp=491818208.718435"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3221&amp;EndingColumnNumber=20&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=472918719.484722"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3226&amp;EndingColumnNumber=20&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=491818208.71854"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3120&amp;EndingColumnNumber=20&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=472918719.484918"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=3125&amp;EndingColumnNumber=20&amp;EndingLineNumber=94&amp;StartingColumnNumber=1&amp;StartingLineNumber=94&amp;Timestamp=491818208.718642"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=3035&amp;EndingColumnNumber=19&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=472918719.485113"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=3040&amp;EndingColumnNumber=19&amp;EndingLineNumber=91&amp;StartingColumnNumber=1&amp;StartingLineNumber=91&amp;Timestamp=491818208.718744"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=12&amp;CharacterRangeLoc=2653&amp;EndingColumnNumber=13&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=472918719.48531"
+         documentLocation = "#CharacterRangeLen=12&amp;CharacterRangeLoc=2658&amp;EndingColumnNumber=13&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=491818208.718846"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2538&amp;EndingColumnNumber=17&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=472918719.485505"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2543&amp;EndingColumnNumber=17&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=491818208.718948"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2297&amp;EndingColumnNumber=15&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=472918719.485706"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2302&amp;EndingColumnNumber=15&amp;EndingLineNumber=75&amp;StartingColumnNumber=1&amp;StartingLineNumber=75&amp;Timestamp=491818208.719048"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=2185&amp;EndingColumnNumber=14&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=472918719.485901"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=2190&amp;EndingColumnNumber=14&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=491818208.719176"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=17&amp;CharacterRangeLoc=2067&amp;EndingColumnNumber=18&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=472918719.486313"
+         documentLocation = "#CharacterRangeLen=17&amp;CharacterRangeLoc=2072&amp;EndingColumnNumber=18&amp;EndingLineNumber=69&amp;StartingColumnNumber=1&amp;StartingLineNumber=69&amp;Timestamp=491818208.719345"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1344&amp;EndingColumnNumber=10&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=472918719.486683"
+         documentLocation = "#CharacterRangeLen=9&amp;CharacterRangeLoc=1349&amp;EndingColumnNumber=10&amp;EndingLineNumber=49&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=491818208.719451"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1307&amp;EndingColumnNumber=9&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=472918719.486916"
+         documentLocation = "#CharacterRangeLen=8&amp;CharacterRangeLoc=1312&amp;EndingColumnNumber=9&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=491818208.719555"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
+++ b/Playgrounds/6a_Threatening_Monad.playground/timeline.xctimeline
@@ -3,83 +3,83 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=673&amp;EndingColumnNumber=11&amp;EndingLineNumber=365&amp;StartingColumnNumber=1&amp;StartingLineNumber=365&amp;Timestamp=491666649.529754"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=673&amp;EndingColumnNumber=11&amp;EndingLineNumber=369&amp;StartingColumnNumber=1&amp;StartingLineNumber=369&amp;Timestamp=493546311.730918"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15638&amp;EndingColumnNumber=12&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491818208.708522"
+         documentLocation = "#CharacterRangeLen=1109&amp;CharacterRangeLoc=15714&amp;EndingColumnNumber=12&amp;EndingLineNumber=358&amp;StartingColumnNumber=1&amp;StartingLineNumber=358&amp;Timestamp=493546385.407026"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14714&amp;EndingColumnNumber=11&amp;EndingLineNumber=338&amp;StartingColumnNumber=1&amp;StartingLineNumber=338&amp;Timestamp=491818208.708658"
+         documentLocation = "#CharacterRangeLen=852&amp;CharacterRangeLoc=14790&amp;EndingColumnNumber=11&amp;EndingLineNumber=342&amp;StartingColumnNumber=1&amp;StartingLineNumber=342&amp;Timestamp=493546385.407239"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17155&amp;EndingColumnNumber=13&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491818208.708788"
+         documentLocation = "#CharacterRangeLen=349&amp;CharacterRangeLoc=17221&amp;EndingColumnNumber=13&amp;EndingLineNumber=384&amp;StartingColumnNumber=1&amp;StartingLineNumber=384&amp;Timestamp=493546398.932028"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17504&amp;EndingColumnNumber=11&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491818208.708918"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17570&amp;EndingColumnNumber=11&amp;EndingLineNumber=396&amp;StartingColumnNumber=1&amp;StartingLineNumber=396&amp;Timestamp=493546398.932229"
          lockedSize = "{769, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17504&amp;EndingColumnNumber=12&amp;EndingLineNumber=392&amp;StartingColumnNumber=1&amp;StartingLineNumber=392&amp;Timestamp=491818208.709053"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=17570&amp;EndingColumnNumber=12&amp;EndingLineNumber=396&amp;StartingColumnNumber=1&amp;StartingLineNumber=396&amp;Timestamp=493546398.932434"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14172&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491818208.70918"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14248&amp;EndingColumnNumber=14&amp;EndingLineNumber=327&amp;StartingColumnNumber=1&amp;StartingLineNumber=327&amp;Timestamp=493546385.407976"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14279&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491818208.709307"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14355&amp;EndingColumnNumber=15&amp;EndingLineNumber=330&amp;StartingColumnNumber=1&amp;StartingLineNumber=330&amp;Timestamp=493546385.408104"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10715&amp;EndingColumnNumber=11&amp;EndingLineNumber=245&amp;StartingColumnNumber=1&amp;StartingLineNumber=245&amp;Timestamp=491818208.709433"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10791&amp;EndingColumnNumber=11&amp;EndingLineNumber=249&amp;StartingColumnNumber=1&amp;StartingLineNumber=249&amp;Timestamp=493546385.408234"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11279&amp;EndingColumnNumber=16&amp;EndingLineNumber=260&amp;StartingColumnNumber=1&amp;StartingLineNumber=260&amp;Timestamp=491818208.709558"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=11355&amp;EndingColumnNumber=16&amp;EndingLineNumber=264&amp;StartingColumnNumber=1&amp;StartingLineNumber=264&amp;Timestamp=493546385.408359"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13829&amp;EndingColumnNumber=17&amp;EndingLineNumber=291&amp;StartingColumnNumber=1&amp;StartingLineNumber=291&amp;Timestamp=491818208.709681"
+         documentLocation = "#CharacterRangeLen=81&amp;CharacterRangeLoc=13905&amp;EndingColumnNumber=17&amp;EndingLineNumber=295&amp;StartingColumnNumber=1&amp;StartingLineNumber=295&amp;Timestamp=493546385.408485"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5328&amp;EndingColumnNumber=6&amp;EndingLineNumber=130&amp;StartingColumnNumber=5&amp;StartingLineNumber=130&amp;Timestamp=491818208.709807"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=5404&amp;EndingColumnNumber=6&amp;EndingLineNumber=134&amp;StartingColumnNumber=5&amp;StartingLineNumber=134&amp;Timestamp=493546385.40861"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6550&amp;EndingColumnNumber=16&amp;EndingLineNumber=120&amp;StartingColumnNumber=1&amp;StartingLineNumber=120&amp;Timestamp=491818208.709932"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=6626&amp;EndingColumnNumber=16&amp;EndingLineNumber=124&amp;StartingColumnNumber=1&amp;StartingLineNumber=124&amp;Timestamp=493546385.408736"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=6663&amp;EndingColumnNumber=17&amp;EndingLineNumber=145&amp;StartingColumnNumber=1&amp;StartingLineNumber=145&amp;Timestamp=491818208.710057"
+         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=6739&amp;EndingColumnNumber=17&amp;EndingLineNumber=149&amp;StartingColumnNumber=1&amp;StartingLineNumber=149&amp;Timestamp=493546385.408863"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=5441&amp;EndingColumnNumber=11&amp;EndingLineNumber=129&amp;StartingColumnNumber=1&amp;StartingLineNumber=129&amp;Timestamp=491818208.710178"
+         documentLocation = "#CharacterRangeLen=10&amp;CharacterRangeLoc=5517&amp;EndingColumnNumber=11&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=493546385.408987"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=5563&amp;EndingColumnNumber=12&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=491818208.710299"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=5639&amp;EndingColumnNumber=12&amp;EndingLineNumber=137&amp;StartingColumnNumber=1&amp;StartingLineNumber=137&amp;Timestamp=493546385.40911"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -99,27 +99,27 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14166&amp;EndingColumnNumber=14&amp;EndingLineNumber=323&amp;StartingColumnNumber=1&amp;StartingLineNumber=323&amp;Timestamp=491818208.710793"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=14242&amp;EndingColumnNumber=14&amp;EndingLineNumber=327&amp;StartingColumnNumber=1&amp;StartingLineNumber=327&amp;Timestamp=493546385.4096"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14273&amp;EndingColumnNumber=15&amp;EndingLineNumber=326&amp;StartingColumnNumber=1&amp;StartingLineNumber=326&amp;Timestamp=491818208.710915"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=14349&amp;EndingColumnNumber=15&amp;EndingLineNumber=330&amp;StartingColumnNumber=1&amp;StartingLineNumber=330&amp;Timestamp=493546385.409724"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14708&amp;EndingColumnNumber=22&amp;EndingLineNumber=337&amp;StartingColumnNumber=1&amp;StartingLineNumber=337&amp;Timestamp=491818208.71105"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14784&amp;EndingColumnNumber=22&amp;EndingLineNumber=341&amp;StartingColumnNumber=1&amp;StartingLineNumber=341&amp;Timestamp=493546385.409848"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15632&amp;EndingColumnNumber=16&amp;EndingLineNumber=354&amp;StartingColumnNumber=1&amp;StartingLineNumber=354&amp;Timestamp=491818208.711172"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=15708&amp;EndingColumnNumber=16&amp;EndingLineNumber=358&amp;StartingColumnNumber=1&amp;StartingLineNumber=358&amp;Timestamp=493546385.409972"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17149&amp;EndingColumnNumber=16&amp;EndingLineNumber=380&amp;StartingColumnNumber=1&amp;StartingLineNumber=380&amp;Timestamp=491818208.711294"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=17215&amp;EndingColumnNumber=16&amp;EndingLineNumber=384&amp;StartingColumnNumber=1&amp;StartingLineNumber=384&amp;Timestamp=493546398.934788"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -135,25 +135,25 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2744&amp;EndingColumnNumber=15&amp;EndingLineNumber=119&amp;StartingColumnNumber=1&amp;StartingLineNumber=119&amp;Timestamp=491818208.711669"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2744&amp;EndingColumnNumber=15&amp;EndingLineNumber=123&amp;StartingColumnNumber=1&amp;StartingLineNumber=123&amp;Timestamp=493546311.734285"
          lockedSize = "{620, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5105&amp;EndingColumnNumber=16&amp;EndingLineNumber=130&amp;StartingColumnNumber=1&amp;StartingLineNumber=130&amp;Timestamp=491818208.711797"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5181&amp;EndingColumnNumber=16&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=493546385.410632"
          lockedSize = "{621, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5182&amp;EndingColumnNumber=16&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=491818208.711924"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5258&amp;EndingColumnNumber=16&amp;EndingLineNumber=137&amp;StartingColumnNumber=1&amp;StartingLineNumber=137&amp;Timestamp=493546385.410774"
          lockedSize = "{898, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5429&amp;EndingColumnNumber=16&amp;EndingLineNumber=140&amp;StartingColumnNumber=1&amp;StartingLineNumber=140&amp;Timestamp=491818208.71205"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=5505&amp;EndingColumnNumber=16&amp;EndingLineNumber=144&amp;StartingColumnNumber=1&amp;StartingLineNumber=144&amp;Timestamp=493546385.410915"
          lockedSize = "{899, 50}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
@@ -169,12 +169,12 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3970&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=491818208.712419"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3970&amp;EndingColumnNumber=16&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=493546311.735321"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10712&amp;EndingColumnNumber=20&amp;EndingLineNumber=251&amp;StartingColumnNumber=1&amp;StartingLineNumber=251&amp;Timestamp=491818208.712541"
+         documentLocation = "#CharacterRangeLen=19&amp;CharacterRangeLoc=10788&amp;EndingColumnNumber=20&amp;EndingLineNumber=255&amp;StartingColumnNumber=1&amp;StartingLineNumber=255&amp;Timestamp=493546385.41145"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -189,7 +189,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3963&amp;EndingColumnNumber=16&amp;EndingLineNumber=112&amp;StartingColumnNumber=1&amp;StartingLineNumber=112&amp;Timestamp=491818208.712905"
+         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=3963&amp;EndingColumnNumber=16&amp;EndingLineNumber=116&amp;StartingColumnNumber=1&amp;StartingLineNumber=116&amp;Timestamp=493546311.735905"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -199,7 +199,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14707&amp;EndingColumnNumber=16&amp;EndingLineNumber=336&amp;StartingColumnNumber=1&amp;StartingLineNumber=336&amp;Timestamp=491818208.713153"
+         documentLocation = "#CharacterRangeLen=21&amp;CharacterRangeLoc=14783&amp;EndingColumnNumber=16&amp;EndingLineNumber=340&amp;StartingColumnNumber=1&amp;StartingLineNumber=340&amp;Timestamp=493546385.412114"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
Converted all playgrounds for Swift 3 beta.
As Swift 3 removed function currying (SE-0002), I had to resort to somewhat uglier syntax. Maybe the documentation text also needs some adaption to explain that.
